### PR TITLE
typo when converting units; see def in the cooling_and_sf func

### DIFF
--- a/src/star_formation/sfr_AGORA.c
+++ b/src/star_formation/sfr_AGORA.c
@@ -202,7 +202,7 @@ double get_starformation_rate(int i)
   double t_freefall;  // Freefall timescale
   double sf_dens_threshold;  // Number density of neutral atomic hydrogen, code units - converted from parameter file value
 
-  sf_dens_threshold=All.StarFormationNumberDensityThreshold*PROTONMASS*pow(All.UnitDensity_in_cgs,-3.);
+  sf_dens_threshold=All.StarFormationNumberDensityThreshold*PROTONMASS*pow(All.UnitDensity_in_cgs,-1.);
 
   flag   = 1; /* default is normal cooling */
 //  egyeff = 0.0;


### PR DESCRIPTION
HI @doctorcbpower  I believe this was a typo? The exponent here should be -1. I believe the way you did in the cooling_and_starformation line 76 is the correct way.