### PR TITLE
Metal advection

### DIFF
--- a/Template-Config.sh
+++ b/Template-Config.sh
@@ -31,9 +31,9 @@
 #JEANS_MASS_BASED #Jeans mass based SF
 
 #USE_GRACKLE
-#GRACKLE_CHEMISTRY=0 #Curretly only grackle mode=0 (lookup tables) with no chemistry network is supported
+#GRACKLE_CHEMISTRY=0 # Curretly only grackle mode=0 (lookup tables) with no chemistry network is supported
 
-#METALS #TODO: Currently gas cells have constant metallicity
+#METALS # Advect all metals, ie metal mass fraction, as a PASSIVE_SCALARS.
 
 #--------------------------------------- Basic operation mode of code; default: 3d with 6 particle types; type 0: gas >0: only gravitationally interacting
 #NTYPES=6                      # number of particle types

--- a/src/cooling/cooling.c
+++ b/src/cooling/cooling.c
@@ -91,14 +91,20 @@ static DoCoolData DoCool;     /*!< cooling data */
 double DoCooling(double u_old, double rho, double dt, double *ne_guess, int i)
 {
   double u, du;
-
+  
 #ifdef USE_GRACKLE
+  
+  if (dt == 0.){
+    return u_old;
+  }
+  else {
   double *ne = &SphP[i].Ne;
   u = CallGrackle(u_old, rho, dt, ne, i, 0);
   return u;
-#endif /* ifdef USE_GRACKLE */
+  }
 
-#ifndef USE_GRACKLE
+#else /* ifndef USE_GRACKLE */
+
   double u_lower, u_upper;
   double ratefact;
   double LambdaNet;
@@ -798,8 +804,8 @@ void InitCool(void)
 {
 #ifdef USE_GRACKLE
    InitGrackle();
-#else /* ifndef  USE_GRACKLE*/
-
+// TODO: #else /* ifndef  USE_GRACKLE*/
+#endif
   /* set default hydrogen mass fraction */
   gs.XH = HYDROGEN_MASSFRAC;
 
@@ -819,7 +825,7 @@ void InitCool(void)
   set_cosmo_factors_for_current_time();
 
   IonizeParams();
-#endif /* USE_GRACKLE */
+// #endif /* TODO: USE_GRACKLE */
 }
 
 /*! \brief Apply the isochoric cooling to all the active gas cells.

--- a/src/cooling/cooling.c
+++ b/src/cooling/cooling.c
@@ -796,9 +796,9 @@ void IonizeParams(void) { IonizeParamsUVB(); }
  */
 void InitCool(void)
 {
-  #ifdef USE_GRACKLE
-  InitGrackle();
-  #endif /* ifdef  */
+#ifdef USE_GRACKLE
+   InitGrackle();
+#else /* ifndef  USE_GRACKLE*/
 
   /* set default hydrogen mass fraction */
   gs.XH = HYDROGEN_MASSFRAC;
@@ -819,6 +819,7 @@ void InitCool(void)
   set_cosmo_factors_for_current_time();
 
   IonizeParams();
+#endif /* USE_GRACKLE */
 }
 
 /*! \brief Apply the isochoric cooling to all the active gas cells.

--- a/src/cooling/cooling.c
+++ b/src/cooling/cooling.c
@@ -94,6 +94,7 @@ double DoCooling(double u_old, double rho, double dt, double *ne_guess, int i)
   
 #ifdef USE_GRACKLE
   
+  /* NOTE: This protects against the call at the very first time-step of the run. dt = 0 and grackle will complain */
   if (dt == 0.){
     return u_old;
   }

--- a/src/cooling/grackle.c
+++ b/src/cooling/grackle.c
@@ -58,7 +58,7 @@ double CallGrackle(double u_old, double rho, double dt, double *ne_guess, int ta
     *All.GrackleFieldData.internal_energy               = u_old;
 
 #ifdef METALS //TODO:
-    *All.GrackleFieldData.metal_density                 = *All.GrackleFieldData.density * P[target].Metallicity[0];
+    *All.GrackleFieldData.metal_density                 = *All.GrackleFieldData.density * SphP[target].Metallicity;
 #else
     *All.GrackleFieldData.metal_density                 = *All.GrackleFieldData.density * 0.02;
 #endif
@@ -314,7 +314,7 @@ void InitGrackle(void)
      *    These are discussed in Turk et. al. (2011). Default: 0.
      */
     my_grackle_data->three_body_rate        = 0;
-    
+   
 #ifdef METALS // TODO: 
     /* Flag to enable metal cooling using the Cloudy tables. If enabled, the cooling table to be used must be specified with the grackle_data_file parameter. Default: 0. */
     my_grackle_data->metal_cooling                     = 1;
@@ -429,4 +429,4 @@ void InitGrackle(void)
         printf("GRACKLE: Grackle Initialized\n");
 }
 
-#endif  /* closes the initial ifdef COOL_GRACKLE */
+#endif  /* USE_GRACKLE */

--- a/src/cooling/grackle.c
+++ b/src/cooling/grackle.c
@@ -60,7 +60,7 @@ double CallGrackle(double u_old, double rho, double dt, double *ne_guess, int ta
 #ifdef METALS //TODO:
     *All.GrackleFieldData.metal_density                 = *All.GrackleFieldData.density * SphP[target].Metallicity;
 #else
-    *All.GrackleFieldData.metal_density                 = *All.GrackleFieldData.density * 0.02;
+    *All.GrackleFieldData.metal_density                 = *All.GrackleFieldData.density * SOLAR_ABUNDANCE;
 #endif
 
     /* UNDEFINED MEMBERS OF THE STRUCT (USEFUL ONLY FOR UNUSED FLAGS)

--- a/src/cooling/grackle.c
+++ b/src/cooling/grackle.c
@@ -58,7 +58,7 @@ double CallGrackle(double u_old, double rho, double dt, double *ne_guess, int ta
     *All.GrackleFieldData.internal_energy               = u_old;
 
 #ifdef METALS //TODO:
-    *All.GrackleFieldData.metal_density                 = *All.GrackleFieldData.density * SphP[target].Metallicity;
+    *All.GrackleFieldData.metal_density                 = *All.GrackleFieldData.density * SphP[target].Metals;
 #else
     *All.GrackleFieldData.metal_density                 = *All.GrackleFieldData.density * SOLAR_ABUNDANCE;
 #endif

--- a/src/hydro/scalars.c
+++ b/src/hydro/scalars.c
@@ -63,15 +63,13 @@ void init_scalars()
     terminate("ScalarIndex.HighResMass initialized incorrectly\n");
 #endif /* #if defined(REFINEMENT_HIGH_RES_GAS) */
 
-#ifdef METALS
-  ScalarIndex.MetallicityMass = scalar_init(&SphP[0].Metallicity, &SphP[0].MetallicityMass, SCALAR_TYPE_PASSIVE);
-  if(ScalarIndex.MetallicityMass == -1)
-    terminate("ScalarIndex.Metallicity initialized incorrectly\n");
-#endif /* ifdef METALS */
-
 #ifdef PASSIVE_SCALARS
   for(int i = 0; i < PASSIVE_SCALARS; i++)
     {
+#ifdef METALS
+      if(i == METALLICITY_INDEX)
+        mpi_printf("Initializing passive scalar: Total Metallicity\n");
+#endif /* METALS */
       scalar_init(&SphP[0].PScalars[i], &SphP[0].PConservedScalars[i], SCALAR_TYPE_PASSIVE);
     }
 #endif /* #ifdef PASSIVE_SCALARS */

--- a/src/hydro/scalars.c
+++ b/src/hydro/scalars.c
@@ -63,6 +63,12 @@ void init_scalars()
     terminate("ScalarIndex.HighResMass initialized incorrectly\n");
 #endif /* #if defined(REFINEMENT_HIGH_RES_GAS) */
 
+#ifdef METALS
+  ScalarIndex.MetallicityMass = scalar_init(&SphP[0].Metallicity, &SphP[0].MetallicityMass, SCALAR_TYPE_PASSIVE);
+  if(ScalarIndex.MetallicityMass == -1)
+    terminate("ScalarIndex.Metallicity initialized incorrectly\n");
+#endif /* ifdef METALS */
+
 #ifdef PASSIVE_SCALARS
   for(int i = 0; i < PASSIVE_SCALARS; i++)
     {

--- a/src/init/begrun.c
+++ b/src/init/begrun.c
@@ -146,12 +146,14 @@ void begrun1(void)
 
   timebins_init(&TimeBinsHydro, "Hydro", &All.MaxPartSph);
   timebins_init(&TimeBinsGravity, "Gravity", &All.MaxPart);
+
 #ifdef BLACKHOLES 
   timebins_init(&TimeBinsBh, "Bh", &All.MaxPartBhs);
-#endif
+#endif /* BLACKHOLES */
+
 #ifdef STARS 
   timebins_init(&TimeBinsStar, "Star", &All.MaxPartStars);
-#endif
+#endif /* STARS */
 
 #if defined(COOLING)
   All.Time = All.TimeBegin;

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -291,7 +291,7 @@ int init(void)
         #endif //* #ifdef OUTPUT_REFBHCOUNTER */
         }
 #endif /* #ifdef REFINEMENT_AROUND_BH*/
-    }
+  }
 
   for(i = 0; i < TIMEBINS; i++)
     TimeBinSynchronized[i] = 1;
@@ -585,7 +585,7 @@ int init(void)
   exch = malloc(6 * sizeof(double));
 #endif 
 
-#ifdef STARS /*need to fix*/
+#ifdef STARS /*need to fix*/ /*TODO: ?? */
   #ifdef STAR_CLUSTER
   for(i=0; i<NumStars; i++)
     {
@@ -600,6 +600,15 @@ int init(void)
     }
   #endif //* #ifdef STAR_CLUSTER */
 #endif /* #ifdef STARS*/
+
+#ifdef METALS
+if (RestartFlag == 0){
+  for(i=0; i<NumGas; i++){
+    SphP[i].Metallicity = All.InitMetallicityinSolar * SOLAR_ABUNDANCE;
+    }
+  }
+#endif /* ifdef METALS */
+
   return -1;  // return -1 means we ran to completion, i.e. not an endrun code
 }
 

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -79,7 +79,7 @@ int init(void)
 /* IonizeParams initalises the Treecool file and such, 
 * which we don't need when using grackle
 */
-#if defined(COOLING) && !defined(USE_GRACKLE)
+#if defined(COOLING) // TODO: && !defined(USE_GRACKLE)
     IonizeParams();
 #endif /* defined(COOLING) && !defined(USE_GRACKLE) */
 
@@ -526,6 +526,16 @@ int init(void)
       mass += P[i].Mass;
     }
 
+/* NOTE: The metals have to be initialised before the PASSIVE_SCALARS.
+ * The value in the PScalars are set to zero during reading ICs. If PConservedScalars are set to zero,
+ * this the same as no advection!
+ * */
+#ifdef METALS
+  for(i=0; i<NumGas; i++){
+    SphP[i].Metallicity = All.InitMetallicityinSolar * SOLAR_ABUNDANCE;
+}
+#endif /* ifdef METALS */
+
 #ifdef PASSIVE_SCALARS
   for(i = 0; i < NumGas; i++)
     {
@@ -604,13 +614,6 @@ int init(void)
   #endif //* #ifdef STAR_CLUSTER */
 #endif /* #ifdef STARS*/
 
-#ifdef METALS
-if (RestartFlag == 0){
-  for(i=0; i<NumGas; i++){
-    SphP[i].Metallicity = All.InitMetallicityinSolar * SOLAR_ABUNDANCE;
-    }
-  }
-#endif /* ifdef METALS */
 
   return -1;  // return -1 means we ran to completion, i.e. not an endrun code
 }

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -76,9 +76,12 @@ int init(void)
           mpi_printf("INIT: Skipping Omega check since we are not doing a dynamical evolution (not all particles may be loaded)\n");
       }
 
-#if defined(COOLING)
-  IonizeParams();
-#endif /* #if defined(COOLING) */
+/* IonizeParams initalises the Treecool file and such, 
+* which we don't need when using grackle
+*/
+#if defined(COOLING) && !defined(USE_GRACKLE)
+    IonizeParams();
+#endif /* defined(COOLING) && !defined(USE_GRACKLE) */
 
   if(All.ComovingIntegrationOn)
     {

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -532,7 +532,7 @@ int init(void)
  * */
 #ifdef METALS
   for(i=0; i<NumGas; i++){
-    SphP[i].Metallicity = All.InitMetallicityinSolar * SOLAR_ABUNDANCE;
+    SphP[i].Metals = All.InitMetallicityinSolar * SOLAR_ABUNDANCE;
 }
 #endif /* ifdef METALS */
 

--- a/src/io/io_fields.c
+++ b/src/io/io_fields.c
@@ -742,9 +742,15 @@ void init_io_fields()
   /* Scalars */
 
 #ifdef PASSIVE_SCALARS
+#ifdef METALS
+  init_field(IO_PASS, "PASS", "Metallicity", MEM_MY_FLOAT, FILE_MY_IO_FLOAT, FILE_MY_IO_FLOAT, PASSIVE_SCALARS, A_SPHP,
+             &SphP[0].Metallicity, 0, GAS_ONLY);
+  init_units(IO_PASS, 0., -1., 0., 1., 0., All.UnitMass_in_g);
+#else /* infdef METALS; TODO: */
   init_field(IO_PASS, "PASS", "PassiveScalars", MEM_MY_FLOAT, FILE_MY_IO_FLOAT, FILE_MY_IO_FLOAT, PASSIVE_SCALARS, A_SPHP,
              &SphP[0].PScalars[0], 0, GAS_ONLY);
   init_units(IO_PASS, 0., -1., 0., 1., 0., All.UnitMass_in_g);
+#endif /* METALS */
 #endif /* #ifdef PASSIVE_SCALARS */
 
   /* OTHER */

--- a/src/io/io_fields.c
+++ b/src/io/io_fields.c
@@ -744,9 +744,9 @@ void init_io_fields()
 #ifdef PASSIVE_SCALARS
 #ifdef METALS
   init_field(IO_PASS, "PASS", "Metallicity", MEM_MY_FLOAT, FILE_MY_IO_FLOAT, FILE_MY_IO_FLOAT, PASSIVE_SCALARS, A_SPHP,
-             &SphP[0].Metallicity, 0, GAS_ONLY);
+             &SphP[0].Metals, 0, GAS_ONLY);
   init_units(IO_PASS, 0., -1., 0., 1., 0., All.UnitMass_in_g);
-#else /* infdef METALS; TODO: */
+#else /* infdef METALS */
   init_field(IO_PASS, "PASS", "PassiveScalars", MEM_MY_FLOAT, FILE_MY_IO_FLOAT, FILE_MY_IO_FLOAT, PASSIVE_SCALARS, A_SPHP,
              &SphP[0].PScalars[0], 0, GAS_ONLY);
   init_units(IO_PASS, 0., -1., 0., 1., 0., All.UnitMass_in_g);

--- a/src/io/parameters.c
+++ b/src/io/parameters.c
@@ -479,13 +479,19 @@ void read_parameter_file(char *fname)
       strcpy(tag[nt], "JeansMassThreshold");
       addr[nt] = &All.JeansMassThreshold;
       id[nt++] = REAL;
-#endif
-#endif
+#endif // JEANS_MASS_BASED
+#endif // defined(USE_SFR) && defined(JEANS_SF)
 
 #ifdef USE_GRACKLE
       strcpy(tag[nt], "GrackleDataFile");
-      addr[nt] = All.GrackleDataFile;
+      addr[nt] = &All.GrackleDataFile;
       id[nt++] = STRING;
+#endif
+
+#ifdef METALS
+      strcpy(tag[nt], "InitMetallicityinSolar");
+      addr[nt] = &All.InitMetallicityinSolar;
+      id[nt++] = REAL;
 #endif
 
 #ifdef MHD_SEEDFIELD

--- a/src/io/read_ic.c
+++ b/src/io/read_ic.c
@@ -436,7 +436,7 @@ void read_ic(const char *fname, int readTypes)
           All.MassTable[4] = 0;
         }
     }
-#endif
+#endif /* USE_SFR */
 
   u_init = (1.0 / GAMMA_MINUS1) * (BOLTZMANN / PROTONMASS) * All.InitGasTemp;
   u_init *= All.UnitMass_in_g / All.UnitEnergy_in_cgs; /* unit conversion */
@@ -496,7 +496,7 @@ void read_ic(const char *fname, int readTypes)
           jb++;
         }
     }
-#endif
+#endif /* BLACKHOLES */
 
 #ifdef STARS
   int js=0;
@@ -509,7 +509,7 @@ void read_ic(const char *fname, int readTypes)
           js++;
         }
     }
-#endif
+#endif /* STARS */
 
   MPI_Barrier(MPI_COMM_WORLD);
 

--- a/src/main/allvars.h
+++ b/src/main/allvars.h
@@ -343,6 +343,11 @@ extern hwloc_cpuset_t cpuset_thread[NUM_THREADS];
 #define COUNT_PASSIVE_SCALARS 0
 #endif /* #ifdef PASSIVE_SCALARS #else */
 
+#ifdef METALS
+#undef COUNT_PASSIVE_SCALARS
+#define COUNT_PASSIVE_SCALARS (PASSIVE_SCALARS + 1)
+#endif /* METALS */
+
 #define MAXSCALARS (COUNT_REFINE + COUNT_PASSIVE_SCALARS)
 #endif /* #if defined(REFINEMENT_HIGH_RES_GAS) ||  defined(PASSIVE_SCALARS)*/
 
@@ -449,6 +454,14 @@ typedef unsigned long long peano1D;
 #define SEC_PER_GIGAYEAR 3.15576e16
 #define SEC_PER_MEGAYEAR 3.15576e13
 #define SEC_PER_YEAR 3.15576e7
+
+#ifdef METALS
+/*! All metals (by mass). 
+* present photospheric abundances from Asplund et al. 2009 (Z=0.0134, proto-solar=0.0142)
+* Anders+Grevesse 1989 (Z=0.0201, proto-solar=0.0213)
+*/
+#define SOLAR_ABUNDANCE 0.0134
+#endif // METALS
 
 #ifndef FOF_PRIMARY_LINK_TYPES
 #define FOF_PRIMARY_LINK_TYPES 2
@@ -1297,6 +1310,10 @@ extern struct global_data_all_processes
   char GrackleDataFile[100];
 #endif
 
+#ifdef METALS
+double InitMetallicityinSolar;
+#endif // METALS
+       
 } All;
 
 /*****************************************************************************
@@ -1540,6 +1557,11 @@ extern struct sph_particle_data
   MyDouble MomentumKickVector[3];
 #endif
 
+#ifdef METALS
+ MyFloat Metallicity;
+ MyFloat MetallicityMass;
+#endif // METALS
+       
 } * SphP,          /*!< holds SPH particle data on local processor */
     *DomainSphBuf; /*!< buffer for SPH particle data in domain decomposition */
 

--- a/src/main/allvars.h
+++ b/src/main/allvars.h
@@ -327,6 +327,19 @@ extern hwloc_cpuset_t cpuset_thread[NUM_THREADS];
 #define IO_SLEEP_TIME 10
 #endif /* #ifdef TOLERATE_WRITE_ERROR */
 
+#ifdef METALS
+  #define METALLICITY_INDEX 0 /* Where metals sit in the scalars array */
+  #ifndef PASSIVE_SCALARS
+    #define PASSIVE_SCALARS 1 /* METALS need PASSIVE_SCALARS */
+  #else
+    /* Save the current value before redefining; 
+     * Some comppiler complain about redefining */
+    #define _OLD_PASSIVE_SCALARS PASSIVE_SCALARS
+    #undef PASSIVE_SCALARS
+    #define PASSIVE_SCALARS (_OLD_PASSIVE_SCALARS + 1)
+  #endif
+#endif /* METALS */
+
 /* calculate appropriate value of MAXSCALARS */
 
 #if defined(REFINEMENT_HIGH_RES_GAS) || defined(PASSIVE_SCALARS)
@@ -342,11 +355,6 @@ extern hwloc_cpuset_t cpuset_thread[NUM_THREADS];
 #else /* #ifdef PASSIVE_SCALARS */
 #define COUNT_PASSIVE_SCALARS 0
 #endif /* #ifdef PASSIVE_SCALARS #else */
-
-#ifdef METALS
-#undef COUNT_PASSIVE_SCALARS
-#define COUNT_PASSIVE_SCALARS (PASSIVE_SCALARS + 1)
-#endif /* METALS */
 
 #define MAXSCALARS (COUNT_REFINE + COUNT_PASSIVE_SCALARS)
 #endif /* #if defined(REFINEMENT_HIGH_RES_GAS) ||  defined(PASSIVE_SCALARS)*/
@@ -455,13 +463,13 @@ typedef unsigned long long peano1D;
 #define SEC_PER_MEGAYEAR 3.15576e13
 #define SEC_PER_YEAR 3.15576e7
 
-#ifdef METALS
+#if defined(METALS) || defined(USE_GRACKLE)
 /*! All metals (by mass). 
 * present photospheric abundances from Asplund et al. 2009 (Z=0.0134, proto-solar=0.0142)
 * Anders+Grevesse 1989 (Z=0.0201, proto-solar=0.0213)
 */
 #define SOLAR_ABUNDANCE 0.0134
-#endif // METALS
+#endif // defined(METALS) || defined(USE_GRACKLE)
 
 #ifndef FOF_PRIMARY_LINK_TYPES
 #define FOF_PRIMARY_LINK_TYPES 2
@@ -1557,10 +1565,12 @@ extern struct sph_particle_data
   MyDouble MomentumKickVector[3];
 #endif
 
+/* NOTE: This is like an alias so that I can access this field without
+ * calling it PScalars
+ * */
 #ifdef METALS
- MyFloat Metallicity;
- MyFloat MetallicityMass;
-#endif // METALS
+#define Metallicity PScalars[METALLICITY_INDEX]
+#endif /* METALS */
        
 } * SphP,          /*!< holds SPH particle data on local processor */
     *DomainSphBuf; /*!< buffer for SPH particle data in domain decomposition */

--- a/src/main/allvars.h
+++ b/src/main/allvars.h
@@ -328,16 +328,10 @@ extern hwloc_cpuset_t cpuset_thread[NUM_THREADS];
 #endif /* #ifdef TOLERATE_WRITE_ERROR */
 
 #ifdef METALS
-  #define METALLICITY_INDEX 0 /* Where metals sit in the scalars array */
-  #ifndef PASSIVE_SCALARS
-    #define PASSIVE_SCALARS 1 /* METALS need PASSIVE_SCALARS */
-  #else
-    /* Save the current value before redefining; 
-     * Some comppiler complain about redefining */
-    #define _OLD_PASSIVE_SCALARS PASSIVE_SCALARS
-    #undef PASSIVE_SCALARS
-    #define PASSIVE_SCALARS (_OLD_PASSIVE_SCALARS + 1)
-  #endif
+#define METALLICITY_INDEX 0 /* Where metals sit in the scalars array */
+#ifndef PASSIVE_SCALARS
+#error "METALS need PASSIVE_SCALARS!"
+#endif /* ifndef PASSIVE_SCALARS*/
 #endif /* METALS */
 
 /* calculate appropriate value of MAXSCALARS */

--- a/src/main/allvars.h
+++ b/src/main/allvars.h
@@ -1563,7 +1563,7 @@ extern struct sph_particle_data
  * calling it PScalars
  * */
 #ifdef METALS
-#define Metallicity PScalars[METALLICITY_INDEX]
+#define Metals PScalars[METALLICITY_INDEX]
 #endif /* METALS */
        
 } * SphP,          /*!< holds SPH particle data on local processor */

--- a/src/main/run.c
+++ b/src/main/run.c
@@ -363,9 +363,9 @@ void do_second_order_source_terms_second_half(void)
  */
 void set_non_standard_physics_for_current_time(void)
 {
-#if defined(COOLING)
+#if defined(COOLING) // TODO: && !defined(USE_GRACKLE)
   IonizeParams(); /* set UV background for the current time */
-#endif            /* #if defined(COOLING) */
+#endif            /* #if defined(COOLING) && !defined(USE_GRACKLE) */
 }
 
 /*! \brief calls extra modules after the gravitational force is recomputed.

--- a/src/mesh/mesh.h
+++ b/src/mesh/mesh.h
@@ -57,9 +57,6 @@ extern struct scalar_index
   int HighResMass;
 #endif /* #ifdef REFINEMENT_HIGH_RES_GAS */
 
-#ifdef METALS
-  int MetallicityMass;
-#endif // METALS
 } ScalarIndex;
 
 extern int N_Scalar; /*!< number of registered scalars */

--- a/src/mesh/mesh.h
+++ b/src/mesh/mesh.h
@@ -56,6 +56,10 @@ extern struct scalar_index
 #ifdef REFINEMENT_HIGH_RES_GAS
   int HighResMass;
 #endif /* #ifdef REFINEMENT_HIGH_RES_GAS */
+
+#ifdef METALS
+  int MetallicityMass;
+#endif // METALS
 } ScalarIndex;
 
 extern int N_Scalar; /*!< number of registered scalars */


### PR DESCRIPTION
Hi Chris & Nick,

This PR adds proper metal advection to Arepo_solas. The metals are defined as a mass fraction. There is a new input parameter `InitMetallicityinSolar` (units of SOLAR_ABUNDANCE = 0.0134) which is how the metals are initialised.

To interact, there is a Metallicity field in the SphP struct. The metallicity is also saved in snapshots. I have tested and the values make sense. 

There is a pesky bug though. Whenever I enable the `STARS` flag, the compilation fails. Stems from this line in starformation.c  
https://github.com/s-balu/arepo_solas/blob/6b0a6067bfe45edf5fcc700382e4f43f89c6725a/src/star_formation/starformation.c#L347

Also line 451.


I see that there is a `Metallicity` field for the struct being passed to `CeLib`. I can of course rename my new field. I am more confused as to how/why this is happening. Any idea why the compiler would confuse these two fields (from a coding perspective)?