### PR TITLE
Fix NULL rng and uninitialized star evolution tables on restart

### DIFF
--- a/src/init/begrun.c
+++ b/src/init/begrun.c
@@ -148,6 +148,40 @@ void begrun1(void)
   gsl_rng_set(random_generator, 42 + ThisTask);
   gsl_rng_set(random_generator_aux, 31452 + ThisTask);
 
+#ifdef STAR_PARTICLES
+  /* IMF tables and RNG for star-particle mass sampling: these depend only on
+   * compile-time constants and All.IMF (already read by read_parameter_file()
+   * above), not on particle data, so set them up here unconditionally rather
+   * than in init(), which is skipped entirely when RestartFlag==1 -- leaving
+   * norm/bin_imf/rng permanently zero/NULL on every restart otherwise. */
+  if(ThisTask == 0)
+    {
+      build_imf_cdf();
+
+#if defined(STAR_PARTICLES) && STAR_PARTICLES < 2
+      setup_mass_bins();
+#endif
+
+#if STAR_PARTICLES == 0
+      setup_imf_integrals();
+#endif
+    }
+  MPI_Bcast(cdf_masses, N_CDF_BINS + 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(cdf_values, N_CDF_BINS + 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+#if defined(STAR_PARTICLES) && STAR_PARTICLES < 2
+  MPI_Bcast(StarMeanMassInBins, NBINS, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+#endif
+
+#if STAR_PARTICLES == 0
+  MPI_Bcast(&norm, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(bin_imf, NBINS, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+  rng = gsl_rng_alloc(gsl_rng_mt19937);
+  gsl_rng_set(rng, ThisTask + 1);
+#endif
+#endif /* #ifdef STAR_PARTICLES */
+
   timebins_init(&TimeBinsHydro, "Hydro", &All.MaxPartSph);
   timebins_init(&TimeBinsGravity, "Gravity", &All.MaxPart);
 

--- a/src/init/begrun.c
+++ b/src/init/begrun.c
@@ -185,9 +185,16 @@ void begrun1(void)
   timebins_init(&TimeBinsHydro, "Hydro", &All.MaxPartSph);
   timebins_init(&TimeBinsGravity, "Gravity", &All.MaxPart);
 
-#ifdef STAR_FEEDBACK_ACTIVE 
+#ifdef STAR_FEEDBACK_ACTIVE
   timebins_init(&TimeBinsStar, "Star", &All.MaxPartStars);
-#endif 
+
+  /* Loaded from a static input file, independent of restart state, so (like
+   * the IMF tables above) this must happen here rather than in init(), which
+   * is skipped on restart -- otherwise Z_VALUES/M_VALUES/N/Age stay NULL for
+   * the life of a restarted run. */
+  mpi_printf("BEGRUN: Loading star evolution tables\n");
+  load_star_tables(All.StarTablesFile);
+#endif
 
 #ifdef BH_ACTIVE
   timebins_init(&TimeBinsBh, "Bh", &All.MaxPartBhs);

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -533,45 +533,15 @@ int init(void)
 
   free_mesh();
 
-#ifdef STAR_PARTICLES
-  if(ThisTask == 0)
-    {
-      build_imf_cdf();
-
-#if defined(STAR_PARTICLES) && STAR_PARTICLES < 2
-      setup_mass_bins();
-#endif
-
-#if STAR_PARTICLES == 0
-      setup_imf_integrals();
-#endif
-    }
-  
-  MPI_Bcast(cdf_masses, N_CDF_BINS + 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-  MPI_Bcast(cdf_values, N_CDF_BINS + 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-
-#if defined(STAR_PARTICLES) && STAR_PARTICLES < 2
-  MPI_Bcast(StarMeanMassInBins, NBINS, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-#endif
-
-#if STAR_PARTICLES == 0
-  MPI_Bcast(&norm, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-  MPI_Bcast(bin_imf, NBINS, MPI_DOUBLE, 0, MPI_COMM_WORLD);
-
-#include <gsl/gsl_rng.h>
-
-  rng = gsl_rng_alloc(gsl_rng_mt19937);
-  gsl_rng_set(rng, ThisTask + 1);
-#endif
+  /* IMF tables and the star-particle RNG are now set up unconditionally in
+   * begrun1(), since it (unlike this function) also runs on restart. */
 
 #if defined(STAR_PARTICLES) && STAR_PARTICLES < 2
   for(i = 0; i < NumStars; i++)
     sample_star_particle(PPS(i).Mass * All.cf_UnitMass_in_Msun, SP[i].NumOfStarsInBins);
 #endif
 
-#endif
-
-#ifdef STAR_FEEDBACK_ACTIVE  
+#ifdef STAR_FEEDBACK_ACTIVE
   mpi_printf("Loading star evolution tables\n");
   load_star_tables(All.StarTablesFile);
 

--- a/src/init/init.c
+++ b/src/init/init.c
@@ -542,9 +542,8 @@ int init(void)
 #endif
 
 #ifdef STAR_FEEDBACK_ACTIVE
-  mpi_printf("Loading star evolution tables\n");
-  load_star_tables(All.StarTablesFile);
-
+  /* load_star_tables() is now called unconditionally in begrun1(), since it
+   * (unlike this function) also runs on restart. */
   feedback_init(&MechanicalFeedbackEvents);
 
   for(i = 0; i < NumStars; i++)


### PR DESCRIPTION
Fixes #27.

Cherry-picked from `merge-fof-into-star-feedback`. `init.c` needed a manual merge (this branch has an extra `sample_star_particle()` loop over existing stars in `init()` that our branch doesn't -- preserved as-is, only the IMF/rng/table setup moved). Verified the underlying bug (rng/tables only set up in `init()`, which is skipped on restart) is present, unfixed, in this branch's current `begrun.c`/`init.c` before opening this PR.

## Commits
- Fix NULL rng and uninitialized IMF tables on restart in `sample_star_particle()`
- Fix NULL star evolution tables (Z_VALUES/M_VALUES/N/Age) on restart

## Verification
Full `SYSTYPE=MACOSX` build against this branch with `STAR_PARTICLES=0` + `STAR_FEEDBACK_ACTIVE` active (via `SUPERNOVAE`): `src/init/begrun.o`, `src/init/init.o` compile clean.