### PR TITLE
Clamp negative gas cell mass from feedback; zero-init BhP[]/SP[] regrowth

### DIFF
--- a/src/stars/star_update.c
+++ b/src/stars/star_update.c
@@ -382,10 +382,28 @@ void star_perform_end_of_step_physics(void)
         continue;
 
 #if defined(WINDS) || defined(SUPERNOVAE)
-      /* Add mass */ 
+      /* Add mass */
+      double old_mass_before_feed = P[i].Mass;
       P[i].Mass += SphP[i].StarMassFeed;
+
+      if(P[i].Mass <= 0)
+        {
+          double floor_mass = fmax(1.0e-3 * All.TargetGasMass, 1.0e-3 * old_mass_before_feed);
+          if(floor_mass <= 0)
+            floor_mass = 1.0e-3 * All.TargetGasMass;
+
+          printf(
+              "WARNING: STAR_FEEDBACK: cell ID=%lld (task=%d, pos=%g|%g|%g) driven to non-positive mass by "
+              "feedback deposition (old Mass=%g, StarMassFeed=%g, resulting Mass=%g) -- clamping to %g\n",
+              (long long)P[i].ID, ThisTask, P[i].Pos[0], P[i].Pos[1], P[i].Pos[2], old_mass_before_feed,
+              SphP[i].StarMassFeed, P[i].Mass, floor_mass);
+          myflush(stdout);
+
+          P[i].Mass = floor_mass;
+        }
+
       All.StarFeedbackLocal[3] += SphP[i].StarMassFeed;
-      
+
       SphP[i].StarMassFeed = 0;
 #if GRACKLE_CHEMISTRY >= 1
       for(int s = 0; s < GRACKLE_SPECIES_NUMBER; s++)

--- a/src/utils/allocate.c
+++ b/src/utils/allocate.c
@@ -162,9 +162,18 @@ void reallocate_memory_maxpartsph(void)
 #ifdef STARS
 void reallocate_memory_maxpartstars(void)
 {
+  /* entries [0, old_NumStars) already hold valid, non-garbage data; memory beyond that (whether
+   * pre-existing zeroed headroom or newly grown by this realloc) is zeroed below, matching the
+   * zero-init guarantee allocate_memory() gives SP[] at initial allocation -- myrealloc_movable()
+   * only preserves the old contents, it does not zero newly grown memory itself */
+  int old_NumStars = NumStars;
+
   mpi_printf("ALLOCATE: Changing to MaxPartStars= %d\n", All.MaxPartStars);
 
   SP = (Star_Particle_Data *)myrealloc_movable(SP, All.MaxPartStars * sizeof(Star_Particle_Data));
+
+  if(All.MaxPartStars > old_NumStars)
+    memset(SP + old_NumStars, 0, (All.MaxPartStars - old_NumStars) * sizeof(Star_Particle_Data));
 
 #ifdef STAR_FEEDBACK_ACTIVE
   timebins_reallocate(&TimeBinsStar);
@@ -175,9 +184,18 @@ void reallocate_memory_maxpartstars(void)
 #ifdef BLACKHOLES
 void reallocate_memory_maxpartbhs(void)
 {
+  /* entries [0, old_NumBhs) already hold valid, non-garbage data; memory beyond that (whether
+   * pre-existing zeroed headroom or newly grown by this realloc) is zeroed below, matching the
+   * zero-init guarantee allocate_memory() gives BhP[] at initial allocation -- myrealloc_movable()
+   * only preserves the old contents, it does not zero newly grown memory itself */
+  int old_NumBhs = NumBhs;
+
   mpi_printf("ALLOCATE: Changing to MaxPartBhs= %d\n", All.MaxPartBhs);
 
   BhP = (struct Bh_Particle_Data *)myrealloc_movable(BhP, All.MaxPartBhs * sizeof(struct Bh_Particle_Data));
+
+  if(All.MaxPartBhs > old_NumBhs)
+    memset(BhP + old_NumBhs, 0, (All.MaxPartBhs - old_NumBhs) * sizeof(struct Bh_Particle_Data));
 
 #ifdef BH_ACTIVE
   timebins_reallocate(&TimeBinsBh);


### PR DESCRIPTION
Fixes #28.

Cherry-picked/split from `merge-fof-into-star-feedback`. The `allocate.c` change is split out of a larger original commit (`9afdd67`) that also touched `fof_distribute.c` for a separate FoF/SubFind BhP[]/SP[] exchange bug -- that machinery doesn't exist on this branch yet, so only the standalone `allocate.c` zero-init piece is included here. Verified both underlying bugs are present, unfixed, in this branch before opening this PR.

## Commits
- Clamp gas cell mass to a positive floor if driven negative by feedback
- Zero newly-grown BhP[]/SP[] memory in `reallocate_memory_maxpartbhs/stars()`

## Verification
Full `SYSTYPE=MACOSX` build against this branch: `src/stars/star_update.o`, `src/utils/allocate.o` compile clean.