### PR TITLE
Self-heal invalid BhP[].TimeBinBh and degenerate SofteningType instead of crashing

### DIFF
--- a/src/blackholes/bh_density.c
+++ b/src/blackholes/bh_density.c
@@ -198,7 +198,28 @@ void bh_density(void)
     {
       Left[i] = Right[i] = 0;
       BhP[i].DensityFlag = 1;
-       
+
+      /* All.SofteningTable[] is only ever populated by set_softenings() for indices in
+       * [0, NSOFTTYPES+NSOFTTYPES_HYDRO) -- the one extra sentinel slot beyond that is
+       * meaningful only for the separate ForceSoftening[] array (explicitly set to 0 there,
+       * see grav_softening.c). A particle whose SofteningType equals that sentinel index (or
+       * is otherwise out of range) reads a never-initialized slot of SofteningTable[], which
+       * is a static global array and so deterministically reads back 0 -- not randomly
+       * corrupted, just the wrong type stored on the particle. A permanent 0 here forces
+       * hmax (below) to 0 forever, which forces Hsml down to 0 on every density iteration
+       * and guarantees the "zero neighbours at maximum Hsml=0" terminate() a few dozen lines
+       * down, regardless of what this Hsml self-heal does, since it reads the same value.
+       * Repair SofteningType itself back to this particle's normal type-based default (the
+       * same value spawn_black_hole_from_cell() assigns a fresh BH) before using it. */
+      if(PPB(i).SofteningType < 0 || PPB(i).SofteningType >= NSOFTTYPES + NSOFTTYPES_HYDRO ||
+         All.SofteningTable[PPB(i).SofteningType] <= 0)
+        {
+          printf("WARNING: BH_DENSITY: BhP[%d] (ID=%llu) has invalid/degenerate SofteningType=%d -- resetting to type default %d\n",
+                 i, (unsigned long long)PPB(i).ID, PPB(i).SofteningType, All.SofteningTypeOfPartType[PPB(i).Type]);
+          myflush(stdout);
+          PPB(i).SofteningType = All.SofteningTypeOfPartType[PPB(i).Type];
+        }
+
       if(BhP[i].Hsml <= 0)
         BhP[i].Hsml = All.SofteningTable[PPB(i).SofteningType];
     }

--- a/src/blackholes/bh_update.c
+++ b/src/blackholes/bh_update.c
@@ -118,13 +118,21 @@ void bh_reconstruct_timebins(void)
            * codebase (see star_reconstruct_timebins()/deactivate_star()); a negative bin
            * has no such meaning and indicates genuinely unexpected state (ASan caught this
            * as a global-buffer-overflow read into TimeBinsBh.TimeBinCount[] via a stale
-           * BhP[i].TimeBinBh). Skip rather than index out of bounds, but flag it loudly --
-           * this BH's physics silently doesn't run this step, which is a soft failure that
-           * still needs tracking down, not a fix in itself. */
-          printf("WARNING: BH_UPDATE: BhP[%d] (ID=%llu) has invalid TimeBinBh=%d (valid range [0,%d)) -- skipping\n", i,
+           * BhP[i].TimeBinBh). Confirmed via production runs to be state baked into the
+           * restart checkpoint itself (predates any swap this run performs), not something
+           * introduced live -- so *skipping* this BH here would orphan it from the timebin
+           * linked list permanently: it would never again be picked up by
+           * bh_update_list_of_active_particles(), silently freezing its gravity/accretion
+           * out for the rest of the run. Reset to bin 0 (the same default a freshly seeded
+           * BH gets, see spawn_black_hole_from_cell()) and fall through to the normal
+           * insertion below instead, so it resumes being tracked -- self-healing rather than
+           * permanently dropping the particle. Flagged loudly since the underlying cause
+           * (how TimeBinBh went negative in the first place) is still unexplained. */
+          printf("WARNING: BH_UPDATE: BhP[%d] (ID=%llu) has invalid TimeBinBh=%d (valid range [0,%d)) -- resetting to bin 0\n", i,
                  (unsigned long long)PPB(i).ID, bin, TIMEBINS);
           myflush(stdout);
-          continue;
+          bin             = 0;
+          BhP[i].TimeBinBh = 0;
         }
 
       if(TimeBinsBh.TimeBinCount[bin] > 0)

--- a/src/blackholes/bh_update.c
+++ b/src/blackholes/bh_update.c
@@ -112,8 +112,20 @@ void bh_reconstruct_timebins(void)
   for(i = 0; i < NumBhs; i++)
     {
       bin = BhP[i].TimeBinBh;
-      if(bin >= TIMEBINS)
-        continue;
+      if(bin < 0 || bin >= TIMEBINS)
+        {
+          /* TIMEBINS is the established "inactive/parked" sentinel elsewhere in this
+           * codebase (see star_reconstruct_timebins()/deactivate_star()); a negative bin
+           * has no such meaning and indicates genuinely unexpected state (ASan caught this
+           * as a global-buffer-overflow read into TimeBinsBh.TimeBinCount[] via a stale
+           * BhP[i].TimeBinBh). Skip rather than index out of bounds, but flag it loudly --
+           * this BH's physics silently doesn't run this step, which is a soft failure that
+           * still needs tracking down, not a fix in itself. */
+          printf("WARNING: BH_UPDATE: BhP[%d] (ID=%llu) has invalid TimeBinBh=%d (valid range [0,%d)) -- skipping\n", i,
+                 (unsigned long long)PPB(i).ID, bin, TIMEBINS);
+          myflush(stdout);
+          continue;
+        }
 
       if(TimeBinsBh.TimeBinCount[bin] > 0)
         {


### PR DESCRIPTION
Fixes #32.

Cherry-picked from `merge-fof-into-star-feedback`. Verified the underlying bugs are present, unfixed, in this branch's current `bh_update.c`/`bh_density.c` before opening this PR.

## Commits
- Fix missing lower-bound check on BhP[].TimeBinBh in bh_reconstruct_timebins()
- bh_update: self-heal invalid TimeBinBh instead of permanently orphaning the BH (supersedes the previous commit's skip-based approach with a proper self-heal)
- bh_density: repair degenerate SofteningType instead of crashing at Hsml=0

## Verification
`src/blackholes/bh_update.o` compiles clean against this branch (with `BLACKHOLES`/`BONDI_ACCRETION` enabled, since this branch's `CosmoConfig.sh` has them off by default).

`src/blackholes/bh_density.c` currently fails to compile with `BLACKHOLES` active at all on this branch, independent of this PR (`u`/`hinv` used but their declaration is commented out around line 378) -- pre-existing, not something this PR touches or introduces. Flagged in #32 as a separate follow-up.