### PR TITLE
Fix missing endif breaking the Makefile for every Config.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -658,6 +658,7 @@ OBJS    += blackholes/bh_seed.o
 INCL    += blackholes/bh_proto.h
 SUBDIRS += blackholes
 endif
+endif # FOF
 
 # SIDM
 ifeq (SIDM,$(findstring SIDM,$(CONFIGVARS)))


### PR DESCRIPTION
## Summary
PR #37 dropped the `endif` closing `ifeq (FOF,$(findstring FOF,$(CONFIGVARS)))` while reorganizing nearby SF-model validation blocks. That `ifeq` never closes, so `make` currently fails to parse the Makefile at all (`Makefile:769: *** missing 'endif'.`) — for **every** Config.sh, not just FOF-related ones. This currently blocks all builds on `main`.

## Fix
Re-added the `endif` in its original position, after the `BLACKHOLE_SEEDING` block and before the `# SIDM` section (matching how `HALO_SEEDING`/`SUBFIND`/`BLACKHOLE_SEEDING` were already nested inside the `FOF` block).

## Test plan
- [x] `Config_SIDM.sh` (no FOF-family flags) compiles and links cleanly.
- [x] `examples/cosmo_box_gravity_only_3d/Config.sh` (`FOF` + `SUBFIND`) compiles and links cleanly, with `fof/*.o` and `subfind/*.o` correctly appearing in the object list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)