### PR TITLE
Fix duplicate reallocate_memory_maxpartbhs() and wrong include paths in sfr_starbystar.c

### DIFF
--- a/src/star_formation/individual_star_formation/sfr_starbystar.c
+++ b/src/star_formation/individual_star_formation/sfr_starbystar.c
@@ -37,10 +37,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../main/allvars.h"
-#include "../main/proto.h"
+#include "../../main/allvars.h"
+#include "../../main/proto.h"
 
-#include "../gravity/forcetree.h"
+#include "../../gravity/forcetree.h"
 
 /* Function that checks whether a cell i satisfies star formation criteria*/
 static int sf_criteria(int i)

--- a/src/utils/allocate.c
+++ b/src/utils/allocate.c
@@ -224,16 +224,3 @@ void reallocate_memory_maxpartbhs(void)
 #endif
 }
 #endif
-
-#ifdef BLACKHOLES
-void reallocate_memory_maxpartbhs(void)
-{
-  mpi_printf("ALLOCATE: Changing to MaxPartBhs= %d\n", All.MaxPartBhs);
-
-  BhP = (struct Bh_Particle_Data *)myrealloc_movable(BhP, All.MaxPartBhs * sizeof(struct Bh_Particle_Data));
-
-#ifdef BH_ACTIVE
-  timebins_reallocate(&TimeBinsBh);
-#endif
-}
-#endif


### PR DESCRIPTION
## Summary
Two independent pre-existing bugs found while auditing preprocessor guard hygiene (separate from the guard rollout itself):

1. **`src/utils/allocate.c`** defined `reallocate_memory_maxpartbhs()` twice under two separate `#ifdef BLACKHOLES` blocks. The second, older copy (missing the zero-init-on-regrow fix the first one has) was a leftover duplicate from an earlier merge. Broke every `BLACKHOLES`+`BH_ACTIVE` build with a redefinition error. Removed the duplicate.

2. **`src/star_formation/individual_star_formation/sfr_starbystar.c`** used `../main/...`/`../gravity/...` include paths (copied from a file one directory shallower — its own `\file` doc comment still says `src/star_formation/sfr_AGORA.c`) instead of `../../main/...` for its actual location. `INDIVIDUAL_STAR_BY_STAR_FORMATION` could not compile as a result. Fixed to match the working convention used by sibling files in the same directory.

## Test plan
- [x] `BLACKHOLES`+`BONDI_ACCRETION`+`BH_THERMAL_FEEDBACK` build compiles and links cleanly.
- [x] `sfr_starbystar.c`'s own "file not found" errors are gone after the path fix.
- [ ] Full `INDIVIDUAL_STAR_BY_STAR_FORMATION` link is still blocked by a separate, unrelated pre-existing gap: `compute_mu()` is only declared/defined under `#ifdef USE_GRACKLE`, but `sfr_starbystar.c`/`sf_starbystar.c`/`sfr_AGORA.c` call it unconditionally, with no enforcement anywhere that these flags require `USE_GRACKLE`. Not fixed here — flagged for a follow-up, same class of issue as the original preprocessor-hygiene investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)