### PR TITLE
Add self-guarding #ifdef wrappers to 23 conditionally-compiled files

### DIFF
--- a/src/blackholes/bh_accretion.c
+++ b/src/blackholes/bh_accretion.c
@@ -8,6 +8,7 @@
 
 #include "../domain/domain.h"
 
+#ifdef BH_ACCRETION_ACTIVE
 
 static int bh_accretion_evaluate(int target, int mode, int threadid);
 static void bh_accretion_rate(void);
@@ -154,7 +155,6 @@ static void out2particle(data_out *out, int i, int mode)
 //#endif
     }
 }
-
 
 #include "../utils/generic_comm_helpers2.h"
 
@@ -743,3 +743,5 @@ static void bh_accretion_rate(void)
   mpi_printf("BLACKHOLES: Number of active blackholes = %lld, Black hole max ADP accretion rate = %e (code units)\n", bh_active, acc_rate_for_print);
 }
 #endif
+
+#endif /* #ifdef BH_ACCRETION_ACTIVE */

--- a/src/blackholes/bh_density.c
+++ b/src/blackholes/bh_density.c
@@ -8,6 +8,7 @@
 
 #include "../domain/domain.h"
 
+#ifdef BH_ACTIVE
 
 static int bh_density_evaluate(int target, int mode, int threadid);
 static int bh_density_isactive(int n);
@@ -105,7 +106,6 @@ static void out2particle(data_out *out, int i, int mode)
 #endif
     }
 }
-
 
 #include "../utils/generic_comm_helpers2.h"
 
@@ -506,3 +506,5 @@ int bh_density_isactive(int n)
 
   return 1;
 }
+
+#endif /* #ifdef BH_ACTIVE */

--- a/src/blackholes/bh_feedback.c
+++ b/src/blackholes/bh_feedback.c
@@ -8,6 +8,7 @@
 
 #include "../domain/domain.h"
 
+#ifdef BH_FEEDBACK_ACTIVE
 
 static int bh_feedback_evaluate(int target, int mode, int threadid);
 
@@ -75,7 +76,6 @@ static void out2particle(data_out *out, int i, int mode)
     {
     }
 }
-
 
 #include "../utils/generic_comm_helpers2.h"
 
@@ -236,3 +236,5 @@ static int bh_feedback_evaluate(int target, int mode, int threadid)
 
   return 0;
 }
+
+#endif /* #ifdef BH_FEEDBACK_ACTIVE */

--- a/src/blackholes/bh_swallow.c
+++ b/src/blackholes/bh_swallow.c
@@ -8,6 +8,7 @@
 
 #include "../domain/domain.h"
 
+#ifdef BH_ACCRETION_ACTIVE
 
 static int bh_swallow_evaluate(int target, int mode, int threadid);
 
@@ -83,7 +84,6 @@ static void out2particle(data_out *out, int i, int mode)
       BhP[i].MassToDrain += out->MassToDrain;
     }
 }
-
 
 #include "../utils/generic_comm_helpers2.h"
 
@@ -291,3 +291,5 @@ static int bh_swallow_evaluate(int target, int mode, int threadid)
 
   return 0;
 }
+
+#endif /* #ifdef BH_ACCRETION_ACTIVE */

--- a/src/blackholes/bh_update.c
+++ b/src/blackholes/bh_update.c
@@ -5,6 +5,7 @@
 #include "../main/allvars.h"
 #include "../main/proto.h"
 
+#ifdef BH_ACTIVE
 
 static int int_compare(const void *a, const void *b)
 {
@@ -323,3 +324,5 @@ void bh_perform_end_of_step_physics(void)
 
 #endif
 } // perform_end_of_step_physics(void)
+
+#endif /* #ifdef BH_ACTIVE */

--- a/src/cooling/cooling.c
+++ b/src/cooling/cooling.c
@@ -59,6 +59,8 @@
 #include "../main/allvars.h"
 #include "../main/proto.h"
 
+#ifdef COOLING
+
 static double Tmin = 0.0;     /*!< min temperature in log10 */
 static double Tmax = 9.0;     /*!< max temperature in log10 */
 static double deltaT;         /*!< log10 of temperature spacing in the interpolation tables */
@@ -947,3 +949,5 @@ void cool_cell(int i)
 
   set_pressure_of_cell(i);
 }
+
+#endif /* #ifdef COOLING */

--- a/src/cooling/grackle.c
+++ b/src/cooling/grackle.c
@@ -7,6 +7,8 @@
 #include "../main/allvars.h"
 #include "../main/proto.h"
 
+#ifdef USE_GRACKLE
+
 /* 'mode' -- tells the routine what to do
  *
  *     0 == solve chemistry and assign new abundances
@@ -620,3 +622,5 @@ double compute_mu(int i)
   /* mu = 1 / sum_s (X_s / A_s), where A_s is the atomic mass in units of m_H */
   return 1.0 / (Xe + XH + XH2 / 2.0 + XD / 2.0 + XHD / 3.0 + XHe / 4.0 + Z / 16.0);
 }
+
+#endif /* #ifdef USE_GRACKLE */

--- a/src/fof/fof_seeding_registry.c
+++ b/src/fof/fof_seeding_registry.c
@@ -46,6 +46,8 @@
 
 #include "fof_seeding.h"
 
+#ifdef HALO_SEEDING
+
 HaloSeedRegistry HaloSeeds;
 
 typedef enum {
@@ -142,3 +144,4 @@ void halo_mark_seeded(HaloSeedRegistry *r, MyIDType id)
     r->n++;
 }
 
+#endif /* #ifdef HALO_SEEDING */

--- a/src/star_formation/individual_star_formation/individual_star_formation.c
+++ b/src/star_formation/individual_star_formation/individual_star_formation.c
@@ -46,13 +46,14 @@
 #include "../../main/allvars.h"
 #include "../../main/proto.h"
 
+#ifdef INDIVIDUAL_STAR_BY_STAR_FORMATION
+
 static void spawn_heavy(int igas, double birthtime, int istar, MyDouble mass_of_star);
 static void spawn_light(int igas, double birthtime, int istar, MyDouble mass_of_star);
 static void make_individual_star(int i, MyDouble mass_of_star, double *local_stars_mass);
 
 static int stars_spawned;      /*!< local number of star particles spawned in the time step */
 static int tot_stars_spawned;  /*!< global number of star paricles spawned in the time step */
-
 
 /*! \brief This routine creates star particles according to their
  *         respective rates.
@@ -437,3 +438,5 @@ static void make_individual_star(int i, MyDouble mass_of_star, double *local_sta
   else 
     spawn_heavy(i, All.Time, j, mass_of_star);
 }
+
+#endif /* #ifdef INDIVIDUAL_STAR_BY_STAR_FORMATION */

--- a/src/star_formation/individual_star_formation/sf_massdrain.c
+++ b/src/star_formation/individual_star_formation/sf_massdrain.c
@@ -7,6 +7,8 @@
 
 #include "../../domain/domain.h"
 
+#ifdef INDIVIDUAL_STAR_BY_STAR_FORMATION
+
 static int sf_massdrain_evaluate(int target, int mode, int threadid);
 
 /*! \brief Local data structure for collecting particle/cell data that is sent
@@ -92,7 +94,6 @@ static void out2particle(data_out *out, int i, int mode)
 #endif
     }
 }
-
 
 #include "../../utils/generic_comm_helpers2.h"
 
@@ -297,3 +298,5 @@ static int sf_massdrain_evaluate(int target, int mode, int threadid)
 
   return 0;
 }
+
+#endif /* #ifdef INDIVIDUAL_STAR_BY_STAR_FORMATION */

--- a/src/star_formation/individual_star_formation/sf_starbystar.c
+++ b/src/star_formation/individual_star_formation/sf_starbystar.c
@@ -7,6 +7,8 @@
 
 #include "../../domain/domain.h"
 
+#ifdef INDIVIDUAL_STAR_BY_STAR_FORMATION
+
 static int sf_starbystar_evaluate(int target, int mode, int threadid);
 static int sf_starbystar_isactive(int n);
 
@@ -75,7 +77,6 @@ static void out2particle(data_out *out, int i, int mode)
       SP[i].NgbsMass += out->NgbsMass;
     }
 }
-
 
 #include "../../utils/generic_comm_helpers2.h"
 
@@ -388,3 +389,5 @@ int sf_starbystar_isactive(int n)
 
   return 1;
 }
+
+#endif /* #ifdef INDIVIDUAL_STAR_BY_STAR_FORMATION */

--- a/src/star_formation/individual_star_formation/sfr_starbystar.c
+++ b/src/star_formation/individual_star_formation/sfr_starbystar.c
@@ -42,6 +42,8 @@
 
 #include "../../gravity/forcetree.h"
 
+#ifdef INDIVIDUAL_STAR_BY_STAR_FORMATION
+
 /* Function that checks whether a cell i satisfies star formation criteria*/
 static int sf_criteria(int i)
 {
@@ -139,3 +141,5 @@ double get_starformation_rate(int i)
 
   return 1;
 }
+
+#endif /* #ifdef INDIVIDUAL_STAR_BY_STAR_FORMATION */

--- a/src/star_formation/sfr_AGORA.c
+++ b/src/star_formation/sfr_AGORA.c
@@ -42,6 +42,8 @@
 
 #include "../gravity/forcetree.h"
 
+#ifdef AGORA_SF
+
 /* Function that checks whether a cell i satisfies star formation criteria*/
 static int sf_criteria(int i)
 {
@@ -166,3 +168,5 @@ double get_starformation_rate(int i)
 
   return rateOfSF;
 }
+
+#endif /* #ifdef AGORA_SF */

--- a/src/star_formation/sfr_JEANS.c
+++ b/src/star_formation/sfr_JEANS.c
@@ -46,6 +46,7 @@
 
 #include "../gravity/forcetree.h"
 
+#ifdef JEANS_SF
 
 /*! \brief Return the Jeans length of the cell.
  *
@@ -204,3 +205,5 @@ double get_starformation_rate(int i)
 
   return rateOfSF;
 }
+
+#endif /* #ifdef JEANS_SF */

--- a/src/star_formation/sfr_eEOS.c
+++ b/src/star_formation/sfr_eEOS.c
@@ -47,6 +47,8 @@
 
 #include "../gravity/forcetree.h"
 
+#ifdef EEOS_SF
+
 /*! \brief Main driver for star formation and gas cooling.
  *
  *  This function loops over all the active gas cells. If a given cell
@@ -545,3 +547,5 @@ double calc_egyeff(int i, double gasdens, double *ne, double *x, double *tsfr, d
 
   return egyeff;
 }
+
+#endif /* #ifdef EEOS_SF */

--- a/src/stars/star.c
+++ b/src/stars/star.c
@@ -1,5 +1,6 @@
 #include "../main/allvars.h"
 
+#ifdef STARS
 
 int NumStars;
 
@@ -12,3 +13,5 @@ Mechanical_Feedback_Events MechanicalFeedbackEvents;
 #endif
 
 Star_Particle_Data *SP;
+
+#endif /* #ifdef STARS */

--- a/src/stars/star_density.c
+++ b/src/stars/star_density.c
@@ -8,6 +8,7 @@
 
 #include "../domain/domain.h"
 
+#ifdef STAR_FEEDBACK_ACTIVE
 
 /* Pass counter: 1 = find host cell, 2 = gather feedback properties */
 static int pass;
@@ -194,7 +195,6 @@ static void out2particle(data_out *out, int i, int mode)
         }
     }
 }
-
 
 #include "../utils/generic_comm_helpers2.h"
 
@@ -609,3 +609,5 @@ int star_density_isactive(int n)
 
   return 1;
 }
+
+#endif /* #ifdef STAR_FEEDBACK_ACTIVE */

--- a/src/stars/star_feedback.c
+++ b/src/stars/star_feedback.c
@@ -7,6 +7,8 @@
 #include "../main/allvars.h"
 #include "../main/proto.h"
 
+#if defined(WINDS) || defined(SUPERNOVAE)
+
 /* SN host-injection modes, returned by SN_feedback_radius() */
 #define MESH 0 /* Couple across Voronoi faces */
 #define HOST 1 /* Thermal dump into host  */
@@ -913,3 +915,5 @@ void star_feedback(void)
  
   TIMER_STOP(CPU_STARS_FEEDBACK);
 }
+
+#endif /* #if defined(WINDS) || defined(SUPERNOVAE) */

--- a/src/stars/star_interpolation.c
+++ b/src/stars/star_interpolation.c
@@ -6,6 +6,7 @@
 #include "../main/allvars.h"
 #include "../main/proto.h"
 
+#ifdef STAR_FEEDBACK_ACTIVE
 
 /* Feedback tables interpolation */
 static inline double linear_interpolation(double x, double x0, double x1, double y0, double y1);
@@ -711,3 +712,5 @@ Star_Feedback star_particle_feedback(int index, double dt, double z, double a)
   return StarParticle;
 }
 #endif
+
+#endif /* #ifdef STAR_FEEDBACK_ACTIVE */

--- a/src/stars/star_radiation.c
+++ b/src/stars/star_radiation.c
@@ -3,6 +3,7 @@
 
 #include "../extern/chealpix.h"
 
+#ifdef STAR_RADIATION_ACTIVE
 
 double HealpixDirs[MAX_NUM_RAYS][3];
 
@@ -897,3 +898,5 @@ void star_radiation(void)
 
   TIMER_STOP(CPU_STARS_RADIATION);
 }
+
+#endif /* #ifdef STAR_RADIATION_ACTIVE */

--- a/src/stars/star_radiation_tree.c
+++ b/src/stars/star_radiation_tree.c
@@ -3,6 +3,7 @@
 #include "../main/allvars.h"
 #include "../main/proto.h"
 
+#ifdef STAR_RADIATION_ACTIVE
 
 static inline int ray_box_intersect(const double *ray_pos, const double *ray_dir,
                                     const MyNgbTreeFloat *rmin, const MyNgbTreeFloat *rmax,
@@ -570,3 +571,5 @@ void raytrace_treewalk(RayPacket *ray, RayWorkStack *work, RayExportBuffer *expo
           }
     }
 }
+
+#endif /* #ifdef STAR_RADIATION_ACTIVE */

--- a/src/stars/star_tables.c
+++ b/src/stars/star_tables.c
@@ -3,6 +3,7 @@
 #include "../main/allvars.h"
 #include "../main/proto.h"
 
+#ifdef STAR_FEEDBACK_ACTIVE
 
 // Main Sequence
 int Z_COUNT = 0;
@@ -573,3 +574,5 @@ void load_star_tables(const char *filename)
           }
     }
 }
+
+#endif /* #ifdef STAR_FEEDBACK_ACTIVE */

--- a/src/stars/star_update.c
+++ b/src/stars/star_update.c
@@ -5,6 +5,7 @@
 #include "../main/allvars.h"
 #include "../main/proto.h"
 
+#ifdef STAR_FEEDBACK_ACTIVE
 
 static int int_compare(const void *a, const void *b)
 {
@@ -463,3 +464,5 @@ void star_perform_end_of_step_physics(void)
     mpi_printf("STARS: Energy given by StarParts = %e, Energy taken up by gas particles = %e \n",
     All.StarFeedbackGlobal[2], All.StarFeedbackGlobal[5]);
 } 
+
+#endif /* #ifdef STAR_FEEDBACK_ACTIVE */


### PR DESCRIPTION
## Summary
The Makefile decides whether each of these files gets compiled at all via its own `OBJS +=` logic gated on a specific `Config.sh` flag, but the files' own source never checked that flag itself — unlike, say, `src/sidm/*.c`, which wrap their entire body in `#ifdef SIDM`. That made the Makefile the *only* thing standing between "flag off" and a file either failing to compile, or silently compiling/linking when it shouldn't.

This surfaced from a collaborator's report while building a parallel CMake+YAML config pipeline: `src/io/parameters.c`'s `ADP_ACCRETION` block sits outside any `BH_ACTIVE` guard. A Makefile auto-derivation cascade does keep that specific case safe (`ADP_ACCRETION` auto-implies `BH_ACTIVE`), but that logic lives only in the Makefile — invisible to a reader of the `.c` file or to any other build tooling.

Proved the failure mode directly: compiling the pre-fix `sfr_eEOS.c` standalone against a real `AGORA_SF`-only config produced 60+ "no member named `PhysDensThresh`" style errors. After wrapping it in `#ifdef EEOS_SF` it compiles cleanly to an empty, harmless object file instead.

## Scope note
An earlier audit pass mis-flagged ~32 additional files (all of `subfind/`, most of `fof/`, and a few smaller ones) as unguarded, due to a shell `echo`-through-a-variable bug that silently truncated file content on certain escape sequences. Those were re-audited with a proper preprocessor-nesting parser and confirmed to already be correctly guarded — left untouched here. This PR only touches the 23 files that are genuinely missing the guard.

## Test plan
- [x] Full build: `COOLING`+`STARS`+`STAR_PARTICLES`+`WINDS`+`SUPERNOVAE`+`EEOS_SF`+`FOF`+`HALO_SEEDING` — compiles and links cleanly (covers `cooling.c`, `starformation.c`, `sfr_eEOS.c`, `star.c`, `star_density.c`, `star_update.c`, `star_interpolation.c`, `star_tables.c`, `star_feedback.c`, `fof_seeding_registry.c`).
- [x] Full build: `BLACKHOLES`+`BONDI_ACCRETION`+`BH_THERMAL_FEEDBACK` — compiles and links cleanly (covers `bh_density.c`, `bh_update.c`, `bh_accretion.c`, `bh_swallow.c`, `bh_feedback.c`).
- [x] `Config_SIDM.sh` (all these flags off) as a control — unaffected, compiles and links cleanly.
- [x] All 23 files: balanced `#ifdef`/`#endif` nesting confirmed programmatically.
- [ ] `grackle.c`, `sfr_AGORA.c`, `sfr_JEANS.c`, `star_radiation.c`, `star_radiation_tree.c`, and 3 `individual_star_formation/*.c` files are verified structurally only (same proven insertion pattern) — Grackle isn't installed in this environment, and a full `INDIVIDUAL_STAR_BY_STAR_FORMATION` link hits a separate, pre-existing, unrelated gap (`compute_mu()` only declared under `#ifdef USE_GRACKLE` but called unconditionally by three files, with no enforcement that these flags require `USE_GRACKLE`) — flagged separately, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)