### PR TITLE
Add USE_GRACKLE fallback for compute_mu() in the two remaining call sites

### DIFF
--- a/src/star_formation/individual_star_formation/sf_starbystar.c
+++ b/src/star_formation/individual_star_formation/sf_starbystar.c
@@ -345,7 +345,13 @@ static int sf_starbystar_evaluate(int target, int mode, int threadid)
 
       if(r2 < h2)
         {
-          double mu = compute_mu(i); 
+#ifdef USE_GRACKLE
+          double mu = compute_mu(i);
+#else /* #ifdef USE_GRACKLE */
+          /* assume full ionization -- same fallback as sfr_AGORA.c/sfr_eEOS.c use when
+           * Grackle isn't tracking species abundances to compute an actual mu */
+          double mu = 4 / (8 - 5 * (1 - HYDROGEN_MASSFRAC));
+#endif /* #ifdef USE_GRACKLE #else */
 
           double number_dens = (SphP[i].Density * All.cf_UnitDensity_in_cgs) / mu / PROTONMASS;
           double temp = (SphP[i].Utherm * All.cf_UnitVelocity_in_cm_per_s * All.cf_UnitVelocity_in_cm_per_s) 

--- a/src/star_formation/individual_star_formation/sfr_starbystar.c
+++ b/src/star_formation/individual_star_formation/sfr_starbystar.c
@@ -47,8 +47,14 @@
 /* Function that checks whether a cell i satisfies star formation criteria*/
 static int sf_criteria(int i)
 {
+#ifdef USE_GRACKLE
   double mu = compute_mu(i);
-  
+#else /* #ifdef USE_GRACKLE */
+  /* assume full ionization -- same fallback as sfr_AGORA.c/sfr_eEOS.c use when
+   * Grackle isn't tracking species abundances to compute an actual mu */
+  double mu = 4 / (8 - 5 * (1 - HYDROGEN_MASSFRAC));
+#endif /* #ifdef USE_GRACKLE #else */
+
   double number_dens = (SphP[i].Density * All.cf_UnitDensity_in_cgs) / mu / PROTONMASS;
   double temp = (SphP[i].Utherm * All.cf_UnitVelocity_in_cm_per_s * All.cf_UnitVelocity_in_cm_per_s) 
   * mu * PROTONMASS * GAMMA_MINUS1 / BOLTZMANN;


### PR DESCRIPTION
## Summary
`compute_mu()` is only declared/defined under `#ifdef USE_GRACKLE`, but `sfr_starbystar.c` and `sf_starbystar.c` (both compiled under `INDIVIDUAL_STAR_BY_STAR_FORMATION`) called it unconditionally, with no enforcement anywhere that this flag requires `USE_GRACKLE`.

A third call site, `sfr_AGORA.c`, turned out to already be correctly guarded (`#ifdef USE_GRACKLE` / `#else` fallback) — it was misidentified as broken in the prior investigation; only these two needed fixing.

## Fix
Reused the exact fallback already established in `sfr_AGORA.c` (and matching the "assume full ionization" `mu` used throughout `sfr_eEOS.c`/`read_ic.c`): `4 / (8 - 5 * (1 - HYDROGEN_MASSFRAC))` when `USE_GRACKLE` isn't set. Not a new physics choice — reusing the codebase's own existing convention for this exact situation.

## Test plan
- [x] Building with `INDIVIDUAL_STAR_BY_STAR_FORMATION` (no `USE_GRACKLE`) through several configurations never produces a `compute_mu`-related error again, all the way to the link stage.
- [ ] `INDIVIDUAL_STAR_BY_STAR_FORMATION` still can't be built end-to-end, but for reasons entirely unrelated to this fix, each hit in turn while chasing this down and none touched here:
  - `SP[].Hsml` gated behind `STAR_FEEDBACK_ACTIVE` but used unconditionally in `individual_star_formation.c`
  - `SP[].Metallicity` gated behind `METALS` but used unconditionally in the same file
  - `sfr_starbystar.c` and `sfr_eEOS.c` both define `cooling_and_starformation()` and get linked together whenever `INDIVIDUAL_STAR_BY_STAR_FORMATION` is combined with `EEOS_SF`/`AGORA_SF`/`JEANS_SF` (which `USE_SFR`'s own Makefile check currently requires one of) — a duplicate-symbol link error

  Same "hidden undocumented dependency" class of issue as the original investigation, but a materially larger, separate cleanup — this feature path appears to have never been built end-to-end. Flagging for a dedicated follow-up rather than expanding this PR further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)