### PR TITLE
Add config_flags.yaml: single source of truth for master-switch/derived Config.sh flags

### DIFF
--- a/.github/workflows/validate-config-flags.yml
+++ b/.github/workflows/validate-config-flags.yml
@@ -1,0 +1,31 @@
+name: Validate config flags
+
+on:
+  pull_request:
+    paths:
+      - "config_flags.yaml"
+      - "Makefile"
+      - "Template-Config.sh"
+      - "template_config*.yaml"
+      - "cmake/parse_yaml.py"
+      - "scripts/validate_config_flags.py"
+  push:
+    branches: [main]
+    paths:
+      - "config_flags.yaml"
+      - "Makefile"
+      - "Template-Config.sh"
+      - "template_config*.yaml"
+      - "cmake/parse_yaml.py"
+      - "scripts/validate_config_flags.py"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install pyyaml
+      - run: python3 scripts/validate_config_flags.py

--- a/Template-Config.sh
+++ b/Template-Config.sh
@@ -3,6 +3,12 @@
 ##################################################
 #  Enable/Disable compile-time options as needed #
 ##################################################
+#
+# Every option below is set directly by the user. Flags that the Makefile
+# computes automatically from other flags (e.g. BH_ACTIVE, STAR_FEEDBACK_ACTIVE)
+# must NOT be added here -- they are never user-settable. See config_flags.yaml
+# at the repo root and documentation/source/config-options.md for the full
+# rules; scripts/validate_config_flags.py enforces this in CI.
 
 #--------------------------------------- SOLAS additions
 #TODO                   # Placeholder, not a real compile-time option; not referenced by the code

--- a/cmake/parse_yaml.py
+++ b/cmake/parse_yaml.py
@@ -1,14 +1,53 @@
 #!/usr/bin/env python3
-import sys, yaml
+import os, sys, yaml
 
 if len(sys.argv) != 3:
     print("Usage: python parse_yaml.py <input_yaml> <build_dir>")
     sys.exit(1)
 
+CONFIG_FLAGS_SPEC = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "config_flags.yaml")
+
+
+def _load_flag_spec():
+    with open(CONFIG_FLAGS_SPEC) as f:
+        spec = yaml.safe_load(f)
+    return spec.get("master_switches", {}), spec.get("derived_flags", {})
+
+
+def expand_derived_flags(result: dict) -> dict:
+    """Return a copy of the yaml config augmented with master-switch
+    expansions and derived (e.g. BH_ACTIVE) flags computed from
+    config_flags.yaml, mirroring what the Makefile derives for an
+    equivalent Config.sh. These flags must never be set directly in the
+    yaml itself -- see config_flags.yaml for the tier-2/tier-3 rules.
+    """
+    master_switches, derived_flags = _load_flag_spec()
+    active = {k.upper() for k, v in result.items() if v is True}
+
+    changed = True
+    while changed:
+        changed = False
+        for name, expansion in master_switches.items():
+            if name in active:
+                for flag in expansion:
+                    if flag not in active:
+                        active.add(flag)
+                        changed = True
+        for name, triggers in derived_flags.items():
+            if name not in active and any(t in active for t in triggers):
+                active.add(name)
+                changed = True
+
+    augmented = dict(result)
+    for name in active:
+        augmented[name.lower()] = True
+    return augmented
+
+
 def yaml_to_cmake(config_file: str, build_dir: str)-> None:
     output = f"{build_dir}/generated_options.cmake"
     with open(config_file) as stream:
-        result = yaml.safe_load(stream)
+        result = expand_derived_flags(yaml.safe_load(stream))
         with open(output, "w") as f:
             for k,v in result.items():
                 if v is True or v is False:
@@ -73,8 +112,8 @@ H5Tset_size(atype, 1);
 """
 
     with open(config_file) as stream:
-        result = yaml.safe_load(stream)
-    
+        result = expand_derived_flags(yaml.safe_load(stream))
+
     with open(f"{build_dir}/arepoconfig.h", 'w') as arepoconfig_file, \
          open(f"{build_dir}/compile_time_info.c", 'w') as compile_time_info_file, \
          open(f"{build_dir}/compile_time_info_hdf5.c", 'w') as compile_time_info_hdf5_file:

--- a/config_flags.yaml
+++ b/config_flags.yaml
@@ -1,0 +1,45 @@
+# Single source of truth for arepo_solas Config.sh flags that are NOT
+# primary, independently user-settable options.
+#
+# Every flag on this repo's Config.sh / Template-Config.sh falls into one
+# of three tiers:
+#
+#   1. Primary options  - set directly by the user (e.g. BONDI_ACCRETION,
+#      WINDS, BLACKHOLES). Not listed here; Template-Config.sh is their
+#      source of truth.
+#
+#   2. master_switches   - user-settable convenience flags that expand to a
+#      set of primary (or other master-switch) flags when enabled. Each
+#      expanded flag also remains independently settable on its own.
+#
+#   3. derived_flags     - NEVER user-settable. Computed as "true iff any of
+#      the listed trigger flags is active". These exist purely to gate code
+#      that is shared across several specific models (e.g. any BH accretion
+#      or feedback model needs the same particle-array / domain / I/O
+#      infrastructure). A derived flag's triggers may themselves be other
+#      derived flags.
+#
+# Enforcement: scripts/validate_config_flags.py checks that
+#   (a) no name under derived_flags ever appears as a standalone `#FLAG`
+#       entry in Template-Config.sh or template_config*.yaml, and
+#   (b) the Makefile's hand-written CONFIGVARS derivation blocks agree with
+#       this file, so the two can't silently drift apart.
+#
+# Consumers:
+#   - Makefile               (hand-written derivation blocks, cross-checked
+#                              against this file by the validator)
+#   - cmake/parse_yaml.py     (computes the same flags for CMake/YAML builds)
+#
+# See documentation/source/config-options.md for the full explanation.
+
+master_switches:
+  STAR_FEEDBACK: [WINDS, RADIATION, SUPERNOVAE]
+  RADIATION: [RADIATION_PRESSURE, PHOTOELECTRIC_HEATING, DISSOCIATION, PHOTOIONIZATION]
+  BH_FEEDBACK: [BH_THERMAL_FEEDBACK, BH_JET_FEEDBACK]
+
+derived_flags:
+  BH_ACCRETION_ACTIVE: [BONDI_ACCRETION, TORQUE_ACCRETION, ADP_ACCRETION]
+  BH_FEEDBACK_ACTIVE: [BH_THERMAL_FEEDBACK, BH_JET_FEEDBACK]
+  BH_ACTIVE: [BH_ACCRETION_ACTIVE, BH_FEEDBACK_ACTIVE]
+  STAR_FEEDBACK_ACTIVE: [WINDS, RADIATION_PRESSURE, PHOTOELECTRIC_HEATING, DISSOCIATION, PHOTOIONIZATION, SUPERNOVAE]
+  STAR_RADIATION_ACTIVE: [RADIATION_PRESSURE, PHOTOELECTRIC_HEATING, DISSOCIATION, PHOTOIONIZATION]

--- a/documentation/source/config-options.md
+++ b/documentation/source/config-options.md
@@ -1,6 +1,49 @@
 Code Configuration
 *************************
 
+Flag tiers: primary, master switch, derived
+============================================
+
+Every compile-time flag documented on this page falls into one of three
+tiers:
+
+1. **Primary options** -- set directly by the user in ``Config.sh`` (or the
+   equivalent ``template_config.yaml`` key for CMake builds). This is the
+   vast majority of flags on this page, e.g. ``BONDI_ACCRETION``, ``WINDS``,
+   ``BLACKHOLES``.
+
+2. **Master switches** -- also user-settable, but enabling one auto-enables a
+   whole set of primary flags as a convenience (each of those flags also
+   remains independently settable on its own). For example, ``BH_FEEDBACK``
+   auto-enables both ``BH_THERMAL_FEEDBACK`` and ``BH_JET_FEEDBACK``.
+
+3. **Derived flags** -- **never** set by the user. These are computed as
+   "true if any of a set of trigger flags is active", and exist purely to
+   gate code shared across several specific physics models (e.g. any BH
+   accretion or feedback model needs the same particle-array, domain, and
+   I/O infrastructure, gated on ``BH_ACTIVE``). Examples: ``BH_ACTIVE``,
+   ``BH_ACCRETION_ACTIVE``, ``BH_FEEDBACK_ACTIVE``, ``STAR_FEEDBACK_ACTIVE``,
+   ``STAR_RADIATION_ACTIVE``.
+
+The single source of truth for tiers 2 and 3 is
+`config_flags.yaml <https://github.com/solas-sims/arepo_solas/blob/main/config_flags.yaml>`_
+at the repository root. It is consumed by:
+
+- ``scripts/validate_config_flags.py``, run in CI on every change to the
+  Makefile, ``Template-Config.sh``, any ``template_config*.yaml``, or
+  ``config_flags.yaml`` itself. It fails the build if a derived flag is ever
+  added as a standalone option to ``Template-Config.sh``/``template_config*.yaml``,
+  or if the Makefile's hand-written derivation blocks drift from the spec.
+- ``cmake/parse_yaml.py``, which computes the same master-switch expansions
+  and derived flags for CMake/YAML-driven builds that the Makefile computes
+  for ``Config.sh``-driven builds, so the two build systems stay behaviourally
+  equivalent.
+
+**If you add a new derived or master-switch flag**, add it to
+``config_flags.yaml`` first, then update the Makefile's ``CONFIGVARS``
+derivation blocks to match -- the CI check will tell you if they disagree.
+Do not add a derived flag as a standalone entry to ``Template-Config.sh``.
+
 Basic operation mode
 ============================
 

--- a/scripts/validate_config_flags.py
+++ b/scripts/validate_config_flags.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Validate config_flags.yaml against the Makefile and the Config.sh templates.
+
+Checks:
+  1. No derived flag (config_flags.yaml: derived_flags) is ever listed as a
+     standalone, user-settable option in Template-Config.sh or any
+     template_config*.yaml file — those flags are computed, never set
+     directly.
+  2. The Makefile's hand-written CONFIGVARS derivation blocks for each
+     master switch / derived flag agree with config_flags.yaml, so the two
+     can't silently drift apart.
+
+Exits non-zero with a description of every violation found.
+"""
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_spec():
+    with open(ROOT / "config_flags.yaml") as f:
+        spec = yaml.safe_load(f)
+    return spec.get("master_switches", {}), spec.get("derived_flags", {})
+
+
+def template_sh_flags(path):
+    text = path.read_text()
+    return set(re.findall(r"^#([A-Za-z_][A-Za-z0-9_]*)", text, re.MULTILINE))
+
+
+def template_yaml_flags(path):
+    with open(path) as f:
+        data = yaml.safe_load(f) or {}
+    return {k.upper() for k in data}
+
+
+def check_not_user_settable(derived_flags, errors):
+    for sh_path in [ROOT / "Template-Config.sh"]:
+        if not sh_path.exists():
+            continue
+        flags = template_sh_flags(sh_path)
+        for name in derived_flags:
+            if name in flags:
+                errors.append(
+                    f"{name} is a derived flag (config_flags.yaml) but appears as a "
+                    f"standalone option in {sh_path.relative_to(ROOT)} — remove it, "
+                    f"it must never be user-settable directly"
+                )
+
+    for yaml_path in ROOT.glob("template_config*.yaml"):
+        flags = template_yaml_flags(yaml_path)
+        for name in derived_flags:
+            if name in flags:
+                errors.append(
+                    f"{name} is a derived flag (config_flags.yaml) but appears as a "
+                    f"standalone key in {yaml_path.relative_to(ROOT)} — remove it, "
+                    f"it must never be user-settable directly"
+                )
+
+
+def check_makefile_agreement(master_switches, derived_flags, errors):
+    makefile = (ROOT / "Makefile").read_text()
+
+    for name, expansion in master_switches.items():
+        pattern = (
+            rf"ifneq \(,\$\(filter {re.escape(name)},\$\(CONFIGVARS\)\)\)\s*\n"
+            rf"CONFIGVARS \+= ([^\n]+)"
+        )
+        m = re.search(pattern, makefile)
+        if not m:
+            errors.append(
+                f"master switch {name}: no matching 'CONFIGVARS +=' block found in "
+                f"Makefile (spec/Makefile drift, or the block's form changed)"
+            )
+            continue
+        makefile_expansion = m.group(1).split()
+        if set(makefile_expansion) != set(expansion):
+            errors.append(
+                f"master switch {name}: config_flags.yaml says {expansion}, "
+                f"Makefile expands to {makefile_expansion}"
+            )
+
+    for name, triggers in derived_flags.items():
+        # Form 1: a Makefile variable "NAME = trigger1 trigger2 ..."
+        m = re.search(rf"^{re.escape(name)}\s*=\s*([^\n]+)$", makefile, re.MULTILINE)
+        if m:
+            makefile_triggers = m.group(1).split()
+        else:
+            # Form 2: inline "ifneq (,$(filter t1 t2,$(CONFIGVARS)))\nCONFIGVARS += NAME"
+            pattern = (
+                rf"ifneq \(,\$\(filter ([^,]+),\$\(CONFIGVARS\)\)\)\s*\n"
+                rf"CONFIGVARS \+= {re.escape(name)}\b"
+            )
+            m2 = re.search(pattern, makefile)
+            if not m2:
+                errors.append(
+                    f"derived flag {name}: no matching Makefile block found "
+                    f"(spec/Makefile drift, or the block's form changed)"
+                )
+                continue
+            makefile_triggers = [t.strip("$()") for t in m2.group(1).split()]
+
+        if set(makefile_triggers) != set(triggers):
+            errors.append(
+                f"derived flag {name}: config_flags.yaml says triggers={triggers}, "
+                f"Makefile says {makefile_triggers}"
+            )
+
+
+def main():
+    master_switches, derived_flags = load_spec()
+    errors = []
+
+    check_not_user_settable(derived_flags, errors)
+    check_makefile_agreement(master_switches, derived_flags, errors)
+
+    if errors:
+        print("config_flags.yaml validation FAILED:\n")
+        for e in errors:
+            print(f"  - {e}")
+        print(f"\n{len(errors)} problem(s) found.")
+        return 1
+
+    print(
+        f"config_flags.yaml OK — {len(master_switches)} master switch(es), "
+        f"{len(derived_flags)} derived flag(s), all consistent with the Makefile "
+        f"and Config.sh templates."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Formalizes the distinction between the three tiers of compile-time flags in this codebase:

1. **Primary options** — set directly by the user (unchanged, `Template-Config.sh` remains their source of truth).
2. **Master switches** — user-settable convenience flags that expand to a set of other flags (`STAR_FEEDBACK`, `RADIATION`, `BH_FEEDBACK`).
3. **Derived flags** — never user-settable, computed as "true iff any trigger flag is active" (`BH_ACTIVE`, `BH_ACCRETION_ACTIVE`, `BH_FEEDBACK_ACTIVE`, `STAR_FEEDBACK_ACTIVE`, `STAR_RADIATION_ACTIVE`).

Tiers 2/3 are now defined once, in `config_flags.yaml`, instead of only living inside the Makefile's hand-written `CONFIGVARS` blocks.

## What's new
- **`config_flags.yaml`** — the spec itself.
- **`scripts/validate_config_flags.py`** (+ CI workflow) — enforces going forward that no derived flag is ever added as a standalone option to `Template-Config.sh` or any `template_config*.yaml`, and cross-checks the Makefile's derivation blocks against the spec so they can't silently drift apart.
- **`cmake/parse_yaml.py`** — now computes the same master-switch/derived-flag expansion the Makefile does. Previously it did a flat 1:1 yaml-key → `#define` mapping with no derivation at all, so a CMake/YAML build with e.g. `bondi_accretion: ON` would compile without `BH_ACTIVE` (used by 18 files) ever being defined. This is the same class of bug originally reported against `CosmoConfig.sh`, now fixed for the CMake path too.
- **`Template-Config.sh`**, **`documentation/source/config-options.md`** — document the three tiers and point at `config_flags.yaml`.

## Not in scope
The Makefile's own derivation logic is untouched (diffed clean against main) — this is a documentation + validation layer on top of it, chosen deliberately to keep regression risk at zero for the existing, working build path.

## Test plan
- [x] `python3 scripts/validate_config_flags.py` passes clean against current `main`
- [x] Verified the validator catches both violation classes (derived flag added to `Template-Config.sh`; Makefile/spec trigger-list drift)
- [x] Ran `cmake/parse_yaml.py` against the real `template_config.yaml` and confirmed `BH_ACCRETION_ACTIVE`/`BH_FEEDBACK_ACTIVE`/`BH_ACTIVE`/`STAR_FEEDBACK_ACTIVE` now appear correctly in both `arepoconfig.h` and `generated_options.cmake`, with non-boolean options (`GRACKLE_CHEMISTRY`, etc.) unaffected
- [x] `diff` against `origin/main:Makefile` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)