### PR TITLE
AGORA disc example: fix Config.sh param mismatches, CWD-relative downloads

### DIFF
--- a/examples/agora_disc_star_formation_3d/README.md
+++ b/examples/agora_disc_star_formation_3d/README.md
@@ -11,6 +11,11 @@ This example does **not** plug into `test.sh` — it downloads external ICs
 and data tables rather than generating them with `create.py`. Run it by
 hand, following the steps below.
 
+`get_ics.sh` and `get_tables.sh` write to `./ICs/`, `./grackle_data/`, and
+`./star_tables/` relative to the current working directory (not to wherever
+the scripts themselves live), so run them from inside this directory — or
+from wherever you've copied it, e.g. a `test.sh`-style run directory.
+
 ## What's in this directory
 
 | File | Purpose |

--- a/examples/agora_disc_star_formation_3d/README.md
+++ b/examples/agora_disc_star_formation_3d/README.md
@@ -63,11 +63,11 @@ embedded groups so the two stay consistent:
 
 Downloads two files (gitignored, same pattern as `ICs/`):
 
-### `./grackle_data/CloudyData_UVB=HM2012_high_density.h5`
+### `./grackle_data/CloudyData_UVB=FG2011_shielded.h5`
 
 Grackle cooling/UV-background table, from
 [grackle_data_files](https://github.com/grackle-project/grackle_data_files)
-(pinned to commit `9286964`). Matches `GRACKLE_CHEMISTRY=3` in `Config.sh`.
+(pinned to commit `9286964`).
 
 ### `./star_tables/star_feedback_tables.hdf5`
 
@@ -125,6 +125,9 @@ reader — see the script's docstring for the full set of options
 
 ## Known gaps / things to revisit
 
+- `InitMetallicityinSolar = 0.1` (required by `METALS`) is an assumed
+  starting value, not one taken from the IC file or validated against this
+  fork's implementation.
 - `param.txt`'s star formation and feedback parameters
   (`NumberDensThreshold=5 cm^-3`, `TemperatureThreshold=1e4 K`,
   `StarFormationEfficiency=0.01`, `SN_LeadTime=3 Myr`,

--- a/examples/agora_disc_star_formation_3d/get_ics.sh
+++ b/examples/agora_disc_star_formation_3d/get_ics.sh
@@ -10,8 +10,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-IC_DIR="${SCRIPT_DIR}/ICs"
+IC_DIR="./ICs"
 IC_FILE="${IC_DIR}/agora_lowres_arepo_ic_without_u-with-grid.hdf5"
 IC_URL="https://www.dropbox.com/scl/fi/m439mkz9vfjvcbflucu3f/agora_lowres_arepo_ic_without_u-with-grid.hdf5?rlkey=c142iij59ruj9nwehj28licsp&dl=1"
 

--- a/examples/agora_disc_star_formation_3d/get_tables.sh
+++ b/examples/agora_disc_star_formation_3d/get_tables.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 GRACKLE_DIR="${SCRIPT_DIR}/grackle_data"
-GRACKLE_FILE="${GRACKLE_DIR}/CloudyData_UVB=HM2012_high_density.h5"
-GRACKLE_URL="https://raw.githubusercontent.com/grackle-project/grackle_data_files/928696482fbe15d9bac4382de6134d95568f099c/input/CloudyData_UVB%3DHM2012_high_density.h5"
+GRACKLE_FILE="${GRACKLE_DIR}/CloudyData_UVB=FG2011_shielded.h5"
+GRACKLE_URL="https://raw.githubusercontent.com/grackle-project/grackle_data_files/928696482fbe15d9bac4382de6134d95568f099c/input/CloudyData_UVB%3DFG2011_shielded.h5"
 
 STAR_TABLES_DIR="${SCRIPT_DIR}/star_tables"
 STAR_TABLES_FILE="${STAR_TABLES_DIR}/star_feedback_tables.hdf5"

--- a/examples/agora_disc_star_formation_3d/get_tables.sh
+++ b/examples/agora_disc_star_formation_3d/get_tables.sh
@@ -6,13 +6,11 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-GRACKLE_DIR="${SCRIPT_DIR}/grackle_data"
+GRACKLE_DIR="./grackle_data"
 GRACKLE_FILE="${GRACKLE_DIR}/CloudyData_UVB=FG2011_shielded.h5"
 GRACKLE_URL="https://raw.githubusercontent.com/grackle-project/grackle_data_files/928696482fbe15d9bac4382de6134d95568f099c/input/CloudyData_UVB%3DFG2011_shielded.h5"
 
-STAR_TABLES_DIR="${SCRIPT_DIR}/star_tables"
+STAR_TABLES_DIR="./star_tables"
 STAR_TABLES_FILE="${STAR_TABLES_DIR}/star_feedback_tables.hdf5"
 STAR_TABLES_URL="https://www.dropbox.com/scl/fi/a085tatarnwrx3we553eu/star_feedback_tables.hdf5?rlkey=t07hdi3t5k18868kojd6nsk1y&dl=1"
 

--- a/examples/agora_disc_star_formation_3d/param.txt
+++ b/examples/agora_disc_star_formation_3d/param.txt
@@ -24,8 +24,6 @@ TimeMax                                 0.5     % ~489 Myr; AGORA-style isolated
 %---- Basic code options that set the type of simulation
 ComovingIntegrationOn                   0
 PeriodicBoundariesOn                    0
-CoolingOn                               1
-StarformationOn                         1
 
 %---- Cosmological parameters (not used, ComovingIntegrationOn=0)
 Omega0                                  0.0
@@ -110,11 +108,14 @@ MaxVolumeDiff                           10
 MinVolume                               1
 MaxVolume                               1.0e9
 
+%---- Metallicity (METALS)
+InitMetallicityinSolar                  0.1
+
 %---- Cooling
 TreecoolFile                            ../../TREECOOL_ep
 
 %---- Grackle (USE_GRACKLE)
-GrackleDataFile                         ./grackle_data/CloudyData_UVB=HM2012_high_density.h5
+GrackleDataFile                         ./grackle_data/CloudyData_UVB=FG2011_shielded.h5
 
 %---- Star formation (AGORA_SF)
 CritOverDensity                         57.7    % inert here: only used when ComovingIntegrationOn=1


### PR DESCRIPTION
## Summary
PR #50 (merged) added `examples/agora_disc_star_formation_3d/` but only carried the first commit before two follow-up fixes landed on the same branch. Because #50 was squash-merged, those follow-ups ended up orphaned from `main`'s history, which made #51 (same source branch) show a spurious conflict. This PR is the same two follow-up commits, cherry-picked cleanly onto current `main` instead:

- Drop `CoolingOn`/`StarformationOn` from `param.txt` (not real parameters in this fork — including them trips the unknown-parameter termination), add `InitMetallicityinSolar` (required by `METALS`), switch `GrackleDataFile` to `CloudyData_UVB=FG2011_shielded.h5` — all found by actually running the example against `Config.sh`.
- Make `get_ics.sh`/`get_tables.sh` write relative to the caller's CWD instead of the script's own location, so they work correctly when copied into a run directory.

Content is identical to what was on `examples/agora-disc-star-formation` (verified via `git diff`, no changes beyond the rebase).

Closes #51 in favor of this (no merge-conflict resolution needed here).

## Test plan
- [ ] `./get_ics.sh` / `./get_tables.sh` populate `ICs/`, `grackle_data/`, `star_tables/` correctly whether run in-place or from a copied run directory
- [ ] `make CONFIG=... ` builds cleanly
- [ ] A short test run starts without the previous unknown-parameter termination

🤖 Generated with [Claude Code](https://claude.com/claude-code)