### PR TITLE
Drop .hdf5 suffix from AGORA disc example's InitCondFile

### DIFF
--- a/examples/agora_disc_star_formation_3d/param.txt
+++ b/examples/agora_disc_star_formation_3d/param.txt
@@ -1,5 +1,5 @@
 %----  Relevant files
-InitCondFile                            ./ICs/agora_lowres_arepo_ic_without_u-with-grid.hdf5
+InitCondFile                            ./ICs/agora_lowres_arepo_ic_without_u-with-grid    % Arepo appends .hdf5 itself for ICFormat=3; the file on disk (from get_ics.sh) keeps the extension
 OutputDir                               ./output
 SnapshotFileBase                        snap
 OutputListFilename                      ./output_list.txt


### PR DESCRIPTION
## Summary
This fix was pushed to `examples/agora-disc-star-formation-v2` after PR #52 had already merged (12 minutes later), so it never made it into `main`. Same content, cherry-picked cleanly onto current `main`.

`read_ic.c`'s `find_files()` appends `.hdf5` itself for `ICFormat=3` (`read_ic.c:1580-1581`); the previous value made Arepo look for a nonexistent `agora_lowres_arepo_ic_without_u-with-grid.hdf5.hdf5`.

## Test plan
- [ ] Run confirms Arepo finds and loads the IC file with this InitCondFile value

🤖 Generated with [Claude Code](https://claude.com/claude-code)