### PR TITLE
Add Phase 1 dust module (single-species production/growth/sputtering/SN destruction)

### DIFF
--- a/DUST_PHASE1_IMPLEMENTATION.md
+++ b/DUST_PHASE1_IMPLEMENTATION.md
@@ -31,7 +31,31 @@ unit tests) before Phase 2b adds species/size resolution.
 | Example | `examples/dust_isolated_disk_3d/` | `Config.sh`/`param.txt` scaffold for the flag combination Phase 1 needs (`STARS`+`SUPERNOVAE`+`WINDS`+`METALS`+`DUST`) — no example in the repo had this combination before. **No IC included** — see that directory's `README.md`. |
 
 Verified: builds and links cleanly both with `DUST` on and off (off-path is
-a true no-op); all 19 standalone rate-law tests pass.
+a true no-op); all 21 standalone rate-law tests pass.
+
+**Rate-law constants verified against Li, Narayanan & Dave (2019,
+arXiv:1906.09277) primary text and Table 1** — cross-checked against a raw
+`pdftotext` extraction of the actual paper, not an AI-summarized secondary
+source. Every constant/functional form in `src/dust/dust.h` was wrong or
+missing something before this pass; all four rate laws were corrected:
+
+| Rate law | Before | After (Li+2019) |
+|---|---|---|
+| SN condensation efficiency | 0.01 | 0.15 (Table 1, `DUST_SN_CONDENSATION_EFFICIENCY`) |
+| Growth `tau_ref` | 30 Myr | 10 Myr |
+| Growth `rho_ref` | 1000 cm⁻³ | 100 cm⁻³ |
+| Growth T-scaling | `sqrt(T_ref/T)` | linear `(T_ref/T)` |
+| Growth metallicity term | absent | `(Z_sun/Z_gas)` added, `dust_growth_rate()` now takes a `Z_gas_massfrac` argument |
+| Sputtering `rho_ref` | 1.0 cm⁻³ | 4.543e-4 cm⁻³ (paper's 1e-27 g/cm³ mass density converted to this code's H-number-density convention) |
+| Sputtering rate | `-M/tau_sp` | `-3*M/tau_sp` (paper's `dM/dt = -M/(tau_sp/3)`) |
+| SN destruction efficiency | none applied | `DUST_SN_DESTRUCTION_EFFICIENCY = 0.3` (eq. 8's epsilon) now multiplied in |
+
+Destruction still reuses this code's own Kim & Ostriker (2015) swept-mass
+estimate in place of the paper's independent `M_s` (see "Scope decisions"
+below) — that structural difference is unchanged, only the missing
+epsilon=0.3 factor was added. Production still applies the efficiency to
+total `SN_MetalsLoss` rather than per-element ejecta (Phase 1's
+single-scalar simplification) — only the 0.01→0.15 magnitude was fixed.
 
 ## Validation results (real Arepo runs, not just unit tests)
 
@@ -70,6 +94,18 @@ invariant violations** under real dynamic SN-driven conditions. This
 confirms the SN production/destruction hooks work correctly, not just
 compile.
 
+**Rerun after the Li+2019 rate-law fixes** (same fast-SN table, 4 MPI
+ranks, `TimeMax=0.005`, `TimeBetSnapshot=0.0002`, 752K gas cells): 10 stars
+formed, 10 feedback events, dust mass rises from first SN through all 16
+snapshots (1.03e-6 → 3.31e-6 in code mass units) with nonzero dust cells
+climbing from 13 to 27010 as it spreads across the mesh, metal mass
+non-decreasing throughout, star count non-decreasing throughout, and
+`check.py`'s full five-check suite (metals, dust, star formation,
+star-forming-gas-fraction, stellar spatial extent) passes with **zero
+`0 <= GasDustMass <= GasMetals` invariant violations** and no ejection
+warnings. Confirms the corrected constants integrate correctly end-to-end,
+not just in the standalone unit tests.
+
 **Environment notes from getting this running** (all fixed inline, not
 dust-specific, but worth knowing about):
 - This repo's `src/cooling/grackle.c` needs the `solas-sims/grackle` fork
@@ -89,6 +125,22 @@ dust-specific, but worth knowing about):
   anywhere near the loop's safety cap) — very likely a transient
   environment/system-contention issue on this dev machine, not a code
   defect. No code changes made; flagging in case it recurs elsewhere.
+- **Stale-object build trap** (found during the rate-law-fix rerun): if an
+  earlier `make` invocation compiled any files against the wrong Grackle
+  headers (e.g. before passing the correct `GRACKLE_INCL`/`GRACKLE_LIB`),
+  incremental `make` will NOT recompile those `.o` files on a later
+  correctly-configured invocation, since the header path is a
+  command-line variable, not a tracked file dependency. The result links
+  fine but corrupts memory at runtime (manifested here as `All.GrackleDataFile`
+  silently truncated before `InitGrackle()`, causing an obscure
+  "Can't open Cooling in ..." HDF5 error deep inside Grackle, unrelated to
+  the actual bug). Fix: `rm -rf <BUILD_DIR> <EXEC>` and rebuild clean
+  whenever `GRACKLE_INCL`/`GRACKLE_LIB` change between invocations.
+  On this dev machine, `SYSTYPE=Darwin GRACKLE_INCL="-I$HOME/software/grackle_solas/include" GRACKLE_LIB="-L$HOME/software/grackle_solas/lib -lgrackle -Wl,-rpath,$HOME/software/grackle_solas/lib -L/opt/homebrew/Cellar/gcc/15.2.0_1/lib/gcc/current"`
+  is needed (the Makefile's default `GRACKLE_INCL`/`GRACKLE_LIB` point at
+  `~/Codes/grackle`, the vanilla install, not the `solas-sims/grackle`
+  fork this repo actually needs; `-lgfortran` also isn't on the default
+  linker search path on this machine).
 
 ## Scope decisions (already made, documented here for reference)
 
@@ -103,18 +155,22 @@ dust-specific, but worth knowing about):
    `star_feedback.c`), not an independent McKee (1989) 6800 M☉ constant —
    more self-consistent with the existing SN physics, but means Phase 1's
    destruction rate is coupled to whatever `SN_HostShellSweepFrac` is set to.
-3. **Rate-law constants are literature-standard placeholders, not verified
-   against a specific source.** Every constant in `src/dust/dust.h` is
-   commented `VERIFY` — none have been checked against Li, Narayanan & Dave
-   (2019) directly.
+3. **Rate-law constants are now verified against Li, Narayanan & Dave
+   (2019) directly** (see "Verified" note above) — all four rate laws'
+   constants/functional forms were corrected to match the paper. The two
+   *structural* simplifications (single total-metals scalar instead of
+   per-element production; destruction reusing this code's own swept-mass
+   estimate instead of the paper's independent `M_s`) are unchanged and
+   still Phase 1 scope decisions, not bugs.
 
 ## What needs to be done
 
 ### Before any physics results can be trusted
-- [ ] **Verify rate-law constants** in `src/dust/dust.h`
-  (`DUST_SN_CONDENSATION_EFFICIENCY`, `DUST_GROWTH_TAU_REF_GYR`/`REF_NH_CGS`/`REF_TEMP_K`,
-  `DUST_SPUTTER_TAU_REF_GYR`/`REF_NH_CGS`/`REF_TEMP_K`/`OMEGA`) against
-  Li, Narayanan & Dave (2019) directly, with collaborators.
+- [x] **Verify rate-law constants** in `src/dust/dust.h` against
+  Li, Narayanan & Dave (2019) directly — done (see "Verified" note above);
+  worth a second look from collaborators given the unit-conversion
+  judgment call on the sputtering reference density (paper gives a mass
+  density, this code's rate laws take H number density).
 - [ ] **Decide on the wind-channel dust production gap.** Either accept SN-only
   as a standing Phase 1 limitation, or prioritize splitting the `WINDS`
   yield table into AGB vs. massive-star components (a `src/stars/`

--- a/DUST_PHASE1_IMPLEMENTATION.md
+++ b/DUST_PHASE1_IMPLEMENTATION.md
@@ -1,0 +1,113 @@
+# Dust Module — Phase 1 Implementation Status
+
+Branch: `dust_module`. Companion to `dust_module_implementation_phaseplan.docx`
+(the phased plan) and the repo audit that preceded it. This document
+describes what Phase 1 actually built, the scope decisions made along the
+way, and what's left before it's science-ready.
+
+## What Phase 1 is
+
+A single-scalar dust mass carried per gas cell, with:
+
+- **Production** — SN-channel dust condensation only (see "Scope decisions" below).
+- **Destruction** — SN shock destruction, McKee (1989)-style swept-mass form.
+- **Growth** — grain accretion, Dwek (1998) timescale form.
+- **Sputtering** — thermal sputtering, Tsai & Mathews (1995) timescale form.
+
+It validates the plumbing (data model, timestep integration, snapshot I/O,
+unit tests) before Phase 2b adds species/size resolution.
+
+## What was implemented, file by file
+
+| Area | Files | What it does |
+|---|---|---|
+| Config/build | `Template-Config.sh`, `Makefile`, `src/main/proto.h` | `DUST` flag (requires `METALS`+`SUPERNOVAE`), gated object files, `dust_proto.h` hooked into the global prototype chain. |
+| Data model | `src/main/allvars.h` | `DUST_INDEX`/`DUST_NUMBER` passive scalar (mirrors `METALS_INDEX`/`METALS_NUMBER` — gets Voronoi flux advection, MPI exchange, and refinement/derefinement handling for free via the existing generic `N_Scalar` machinery). `GasDustMass`/`GasDustMassFraction` aliases, `StarDustFeed` staging field, `IO_DUST_MASS` enum entry. |
+| Rate laws | `src/dust/dust_production_sn.c`, `dust_destruction_sn.c`, `dust_growth.c`, `dust_sputtering.c` | Pure functions, no Arepo dependency (testable standalone). Constants isolated in `src/dust/dust.h`. |
+| Integration | `src/dust/dust_update.c` | `dust_cell()` — per-cell growth+sputtering rate-ODE (bracket+bisect on implicit backward-Euler, mirrors `DoCooling()`), clamped to `0 <= GasDustMass <= GasMetals`. `dust_processes()` — driver over `TimeBinsHydro`, called from `src/main/run.c` right after cooling each step. |
+| Snapshot I/O | `src/dust/dust_io.c`, `src/io/io_fields.c` | `DustMass` field registered in snapshots. |
+| SN hook | `src/stars/star_feedback.c`, `star_update.c`, `src/mesh/mesh.h`, `src/mesh/voronoi/voronoi_exchange.c` | Production/destruction wired into the existing per-SN-event `Feedback_Kick` mechanism (both HOST and MESH deposition modes), including the `PrimExch` ghost-cell mirror needed for MPI-remote neighbor cells. |
+| Tests | `tests/dust/` | Standalone unit tests for the four rate-law functions (19 checks, no MPI/mesh needed). Run via `tests/dust/build.sh`. |
+| Example | `examples/dust_isolated_disk_3d/` | `Config.sh`/`param.txt` scaffold for the flag combination Phase 1 needs (`STARS`+`SUPERNOVAE`+`WINDS`+`METALS`+`DUST`) — no example in the repo had this combination before. **No IC included** — see that directory's `README.md`. |
+
+Verified: builds and links cleanly both with `DUST` on and off (off-path is
+a true no-op); all 19 standalone rate-law tests pass.
+
+## Scope decisions (already made, documented here for reference)
+
+1. **SN-channel production only.** This code's `WINDS` channel blends
+   massive-star and AGB-type mass loss into a single table — there's no way
+   to isolate true AGB ejecta from it, so wind-channel dust condensation
+   (which is where most dust production happens in the literature) is
+   deferred. Flag this to collaborators; it's a real physics gap, not a
+   minor detail.
+2. **Destruction is tied to this code's own swept-mass estimate** (Kim &
+   Ostriker 2015 shell mass, already computed for momentum-cap purposes in
+   `star_feedback.c`), not an independent McKee (1989) 6800 M☉ constant —
+   more self-consistent with the existing SN physics, but means Phase 1's
+   destruction rate is coupled to whatever `SN_HostShellSweepFrac` is set to.
+3. **Rate-law constants are literature-standard placeholders, not verified
+   against a specific source.** Every constant in `src/dust/dust.h` is
+   commented `VERIFY` — none have been checked against Li, Narayanan & Dave
+   (2019) directly.
+
+## What needs to be done
+
+### Before any physics results can be trusted
+- [ ] **Verify rate-law constants** in `src/dust/dust.h`
+  (`DUST_SN_CONDENSATION_EFFICIENCY`, `DUST_GROWTH_TAU_REF_GYR`/`REF_NH_CGS`/`REF_TEMP_K`,
+  `DUST_SPUTTER_TAU_REF_GYR`/`REF_NH_CGS`/`REF_TEMP_K`/`OMEGA`) against
+  Li, Narayanan & Dave (2019) directly, with collaborators.
+- [ ] **Decide on the wind-channel dust production gap.** Either accept SN-only
+  as a standing Phase 1 limitation, or prioritize splitting the `WINDS`
+  yield table into AGB vs. massive-star components (a `src/stars/`
+  change, not a dust-module change).
+
+### To actually run and validate Phase 1
+- [ ] Supply an isolated-disk (or similar idealized ISM) **initial conditions
+  file** for `examples/dust_isolated_disk_3d/`.
+- [ ] Supply a **Grackle chemistry/cooling data file** (`GrackleDataFile` in
+  `param.txt`).
+- [ ] Supply the **stellar yield/feedback table** (`StarTablesFile` in
+  `param.txt`, consumed by `load_star_tables()`).
+- [ ] Tune the placeholder parameters in `param.txt` (`BoxSize`,
+  `ReferenceGasPartMass`, `MeanVolume`, softening lengths, `SN_LeadTime`,
+  `SN_HostShellSweepFrac`, `NumberDensThreshold`, `TemperatureThreshold`,
+  `StarFormationEfficiency`, `InitMetallicityinSolar`) to match whatever IC
+  is supplied.
+- [ ] Run the **Phase 1 exit gate**:
+  - Zero-rate bit-for-bit check: build with `DUST` on and off, with rate
+    constants effectively zeroed (e.g. `DUST_SN_CONDENSATION_EFFICIENCY 0`),
+    confirm the two runs agree to machine precision outside `DustMass`.
+  - Metal mass conservation: `GasMetals` (gas-phase + dust-phase) conserved
+    over the run.
+  - D/Z–metallicity trend qualitatively consistent with Li et al. (2019)'s
+    published relation.
+- [ ] Note this build environment's local `Config_AGORA.sh`/`USE_GRACKLE`
+  path currently fails to compile against the Grackle library installed on
+  this dev machine (API version mismatch, pre-existing and unrelated to
+  dust) — verification here used a `USE_GRACKLE`-free config instead. Confirm
+  the real run environment (cluster) has a matching Grackle version before
+  using `Config_AGORA.sh`-style flags for real.
+
+### Beyond Phase 1 (already scoped in the phaseplan doc, not started)
+- **Phase 2a** (metals-model track, not dust-module work): extend chemical
+  enrichment from the current single total-metals scalar to per-element
+  (Mg, Si, O, C, Fe) tracking — owned separately, to be verified with
+  collaborators.
+- **Phase 2b** (blocked on 2a): 3 species × N size bins, species-resolved
+  sputtering/SN destruction, sub-resolved clumping factor.
+- **Phase 3**: shattering, coagulation, turbulent diffusion (no existing
+  diffusion solver in this codebase — confirmed absent in the earlier
+  repo audit, would need to be built from scratch).
+- **Phase 4** (optional, not scheduled by default): two-fluid dynamical dust
+  particles, only if a specific science case needs resolved dust–gas drift.
+
+## Where to look for more detail
+
+- `dust_module_implementation_phaseplan.docx` — the full phased plan,
+  including the Phase 2a/2b split rationale and cross-cutting practices.
+- Git log on `dust_module` (8 commits, `9f085e3`..`8f51d73`) — each commit
+  is scoped to one logical piece (build wiring, data model, rate laws,
+  SN hook, run.c integration, snapshot I/O, tests, example scaffold) and
+  has a detailed message.

--- a/DUST_PHASE1_IMPLEMENTATION.md
+++ b/DUST_PHASE1_IMPLEMENTATION.md
@@ -33,6 +33,63 @@ unit tests) before Phase 2b adds species/size resolution.
 Verified: builds and links cleanly both with `DUST` on and off (off-path is
 a true no-op); all 19 standalone rate-law tests pass.
 
+## Validation results (real Arepo runs, not just unit tests)
+
+Run against `examples/agora_disc_star_formation_3d/` (ported from `main`,
+see git log) — an isolated AGORA-disc IC with `STARS`+`SUPERNOVAE`+`WINDS`+
+`METALS`+`USE_GRACKLE` all enabled, 752K gas cells.
+
+**Structural check** (short run, no SN yet): gas and metal mass conserved,
+`DustMass` present in snapshots and correctly zero everywhere pre-SN
+(production is SN-only; growth has no seed to grow from), zero invariant
+violations.
+
+**Physics check** (SN actually firing): the organic run doesn't produce a
+supernova quickly enough to check in reasonable wall-clock time — real
+massive-star lifetimes are Myr-scale and the IMF makes SN-eligible stars
+(≥8 M☉) rare in a small early population. Forced this by patching a local
+copy of the stellar yield table (`star_feedback_tables.hdf5`): rescaled the
+`Age` track (`star_interpolation.c`'s `star_lifetime()` reads its last
+entry as the star's lifetime, in years) down by 1e5 for every
+`(Z, M)` entry with `M >= 8` and `SN_MassLoss > 0`, so any SN-eligible star
+sampled explodes almost immediately instead of after Myr. Result:
+
+| Snapshot | Time | Stars | Total `DustMass` | Nonzero dust cells | Invariant violations |
+|---|---|---|---|---|---|
+| before any SN | — | 0 | 0 | 0 | 0 |
+| first SN fires | — | 2 | 2.00e-08 | 25 | 0 |
+| — | — | 2 | 1.99e-08 | 209 | 0 |
+| second SN fires | — | 3 | 2.34e-08 | 620 | 0 |
+
+Dust appears exactly when the first SN fires, spreads across the mesh via
+the MESH-mode `Feedback_Kick` redistribution (25 → 209 → 620 nonzero
+cells) as designed, and total mass both rises (fresh production) and dips
+(destruction winning a step) as expected from combined production +
+destruction physics — with **zero `0 <= GasDustMass <= GasMetals`
+invariant violations** under real dynamic SN-driven conditions. This
+confirms the SN production/destruction hooks work correctly, not just
+compile.
+
+**Environment notes from getting this running** (all fixed inline, not
+dust-specific, but worth knowing about):
+- This repo's `src/cooling/grackle.c` needs the `solas-sims/grackle` fork
+  specifically (has `RT_HI/HeI/HeII_heating_rate` fields that upstream
+  Grackle doesn't) — built locally at `~/software/grackle_solas`.
+- Two pre-existing bugs on `Star_feedback_radiation` blocked building at
+  all: an unbalanced `Makefile` (orphaned `endif`s around
+  `FOF`/`HALO_SEEDING`) and a missing `#ifdef RAD_OPENING_ANGLE` guard
+  around `NodeAspectRatio` in `src/io/parameters.c`. Both fixed in the
+  `991754c` merge commit.
+- The AGORA example's `param.txt` (as pulled from `main`) had a
+  `CritOverDensity` line that's only a valid parameter under `EEOS_SF`,
+  not `AGORA_SF` — removed in `3d6c98f`.
+- One apparent 30+ minute hang in `sample_star_particle()`
+  (`src/stars/star_particle.c`, `STAR_PARTICLES=1` IMF sampling) did not
+  reproduce on a rerun with diagnostic instrumentation (zero iterations
+  anywhere near the loop's safety cap) — very likely a transient
+  environment/system-contention issue on this dev machine, not a code
+  defect. No code changes made; flagging in case it recurs elsewhere.
+
 ## Scope decisions (already made, documented here for reference)
 
 1. **SN-channel production only.** This code's `WINDS` channel blends
@@ -64,31 +121,29 @@ a true no-op); all 19 standalone rate-law tests pass.
   change, not a dust-module change).
 
 ### To actually run and validate Phase 1
-- [ ] Supply an isolated-disk (or similar idealized ISM) **initial conditions
-  file** for `examples/dust_isolated_disk_3d/`.
-- [ ] Supply a **Grackle chemistry/cooling data file** (`GrackleDataFile` in
-  `param.txt`).
-- [ ] Supply the **stellar yield/feedback table** (`StarTablesFile` in
-  `param.txt`, consumed by `load_star_tables()`).
-- [ ] Tune the placeholder parameters in `param.txt` (`BoxSize`,
-  `ReferenceGasPartMass`, `MeanVolume`, softening lengths, `SN_LeadTime`,
+- [x] Real IC / Grackle data / star tables — solved via
+  `examples/agora_disc_star_formation_3d/` (ported from `main`, includes
+  `get_ics.sh`/`get_tables.sh` downloaders), not the placeholder
+  `examples/dust_isolated_disk_3d/` scaffold. Consider pointing
+  `dust_isolated_disk_3d/` at this instead, or retiring it, now that a
+  real working example exists.
+- [x] Metal mass conservation — held across every run, including the
+  SN-firing one.
+- [x] SN production/destruction actually firing, with correct invariants
+  — see "Validation results" above.
+- [ ] Zero-rate bit-for-bit check (`DUST` on vs. off with rate constants
+  zeroed) — not yet run.
+- [ ] D/Z–metallicity trend vs. Li et al. (2019) — needs a much longer,
+  statistically meaningful run (the validation run here used an
+  artificially shortened stellar lifetime table specifically to force a
+  fast SN; not representative of real D/Z evolution). A real check needs
+  the *unpatched* table and enough runtime for organic star formation/SN
+  statistics to build up.
+- [ ] Tune the placeholder parameters in `param.txt` (`SN_LeadTime`,
   `SN_HostShellSweepFrac`, `NumberDensThreshold`, `TemperatureThreshold`,
-  `StarFormationEfficiency`, `InitMetallicityinSolar`) to match whatever IC
-  is supplied.
-- [ ] Run the **Phase 1 exit gate**:
-  - Zero-rate bit-for-bit check: build with `DUST` on and off, with rate
-    constants effectively zeroed (e.g. `DUST_SN_CONDENSATION_EFFICIENCY 0`),
-    confirm the two runs agree to machine precision outside `DustMass`.
-  - Metal mass conservation: `GasMetals` (gas-phase + dust-phase) conserved
-    over the run.
-  - D/Z–metallicity trend qualitatively consistent with Li et al. (2019)'s
-    published relation.
-- [ ] Note this build environment's local `Config_AGORA.sh`/`USE_GRACKLE`
-  path currently fails to compile against the Grackle library installed on
-  this dev machine (API version mismatch, pre-existing and unrelated to
-  dust) — verification here used a `USE_GRACKLE`-free config instead. Confirm
-  the real run environment (cluster) has a matching Grackle version before
-  using `Config_AGORA.sh`-style flags for real.
+  `StarFormationEfficiency`, `InitMetallicityinSolar`) — currently
+  literature-typical defaults per that example's own README, not
+  validated against this fork.
 
 ### Beyond Phase 1 (already scoped in the phaseplan doc, not started)
 - **Phase 2a** (metals-model track, not dust-module work): extend chemical

--- a/Makefile
+++ b/Makefile
@@ -535,6 +535,25 @@ $(warning SUPERNOVAE without TREE_BASED_TIMESTEPS does not limit timesteps)
 endif
 endif
 
+#DUST
+ifneq (,$(filter DUST,$(CONFIGVARS)))
+ifeq (,$(filter METALS,$(CONFIGVARS)))
+$(error DUST requires METALS)
+endif
+ifeq (,$(filter SUPERNOVAE,$(CONFIGVARS)))
+$(error DUST requires SUPERNOVAE (Phase 1 dust production/destruction is SN-channel only))
+endif
+OBJS += dust/dust_production_sn.o \
+        dust/dust_destruction_sn.o \
+        dust/dust_growth.o \
+        dust/dust_sputtering.o \
+        dust/dust_update.o \
+        dust/dust_io.o
+INCL += dust/dust.h \
+        dust/dust_proto.h
+SUBDIRS += dust
+endif
+
 #BLACKHOLES
 ifneq (,$(filter BLACKHOLES,$(CONFIGVARS)))
 OBJS += blackholes/bh.o

--- a/Template-Config.sh
+++ b/Template-Config.sh
@@ -22,6 +22,16 @@
 #_MPI                   # Requires ENABLE_PROFILE_UTIL; also logs MPI-specific profiling data (node memory, MPI comm binding)
 #USE_CELIB              # Use the CELib libraries
 
+#---------------------------------------- Dust parameters
+#DUST                   # Single-species dust mass, advected as a PASSIVE_SCALARS (requires METALS). Phase 1: production (SN-channel only)/growth/sputtering/SN-destruction.
+#DUST_SPECIES=1         # (not yet implemented, Phase 2b) number of dust species carried per cell; Phase 1 code is written to be indexed by species so this only needs to grow later
+#DUST_SIZE_BINS         # (not yet implemented, Phase 2b) piecewise-linear grain-size bin discretization (McKinnon 2018)
+#DUST_LIVE              # (not yet implemented, Phase 4) two-fluid dynamical dust particles
+
+#---------------------------------------- Cooling parameters
+#USE_GRACKLE
+#GRACKLE_CHEMISTRY=0    # Curretly only grackle mode=0 (lookup tables) with no chemistry network is supported
+
 #---------------------------------------- Star Formation options
 #EEOS_SF                # Default SF scheme in Arepo
 #AGORA_SF               # Agora based SF

--- a/examples/agora_disc_star_formation_3d/Config.sh
+++ b/examples/agora_disc_star_formation_3d/Config.sh
@@ -10,6 +10,9 @@
 #--------------------------------------- Metal parameters
 METALS                 # Advect all metals, ie metal mass fraction, as a PASSIVE_SCALARS
 
+#--------------------------------------- Dust parameters
+DUST                   # Phase 1: single-species dust mass (SN-channel production/destruction, growth, sputtering)
+
 #--------------------------------------- Cooling parameters
 USE_GRACKLE
 GRACKLE_CHEMISTRY=3

--- a/examples/agora_disc_star_formation_3d/README.md
+++ b/examples/agora_disc_star_formation_3d/README.md
@@ -127,7 +127,10 @@ mpiexec -np <N> ./Arepo ./param.txt
 
 ```bash
 python agora_disc_diagnostics.py --snapshot output/snap_000.hdf5 output/snap_010.hdf5 \
-    --output disc_profiles.png --grid-output "disc_grid_{name}.png"
+    --output disc_profiles.png --grid-output "disc_grid_{name}.png" \
+    --metals-grid-output "disc_grid_metals_{name}.png" \
+    --dust-grid-output "disc_grid_dust_{name}.png" \
+    --metals-dust-output "disc_metals_dust_profiles.png"
 ```
 
 Produces overlaid radial surface-density / scale-height / vertical velocity
@@ -136,6 +139,16 @@ density-grid projection image per snapshot. Uses the group's `analysistools`
 package if installed, otherwise falls back to a self-contained `h5py`-based
 reader — see the script's docstring for the full set of options
 (`--mask-radius`, `--ngrid`, `--save-data`, etc).
+
+Also reads each snapshot's gas-cell metal mass (`PassiveScalars`) and, if
+present, dust mass (`DustMass`, only written when `Config.sh` has `DUST`
+enabled) directly from `PartType0`. This produces the same smoothed-grid
+XY/XZ/YZ projection as gas mass gets (`disc_grid_metals_*`/
+`disc_grid_dust_*`), plus a second overlaid-profile figure
+(`disc_metals_dust_profiles.png`) of metal and dust surface density vs.
+radius, mirroring the gas surface-density panel. The dust grid/profile is
+skipped (with a log message, not an error) if the run has no `DustMass`
+field.
 
 ## 6. Sanity checks
 

--- a/examples/agora_disc_star_formation_3d/README.md
+++ b/examples/agora_disc_star_formation_3d/README.md
@@ -25,6 +25,7 @@ from wherever you've copied it, e.g. a `test.sh`-style run directory.
 | `get_ics.sh` | Downloads the initial conditions into `./ICs/` |
 | `get_tables.sh` | Downloads the Grackle cooling table and stellar feedback table into `./grackle_data/` and `./star_tables/` |
 | `agora_disc_diagnostics.py` | Post-processing: radial surface density / scale height / vertical velocity dispersion profiles, plus a smoothed density-grid projection, from one or more output snapshots |
+| `check.py` | Sanity checks (not a reference-solution comparison): total metal mass never decreases across snapshots, and every gas cell's `DustMass` stays within `0 <= DustMass <= GasMetals` at every snapshot (skipped with a message if the run wasn't built with `DUST`) |
 
 ## 1. Get the initial conditions
 
@@ -136,6 +137,30 @@ package if installed, otherwise falls back to a self-contained `h5py`-based
 reader — see the script's docstring for the full set of options
 (`--mask-radius`, `--ngrid`, `--save-data`, etc).
 
+## 6. Sanity checks
+
+```bash
+python check.py .
+```
+
+Run from this directory (or pass whatever directory contains your
+`output/`). Two checks, printed per-snapshot and summarized pass/fail:
+
+- **Metals**: total metal mass (gas-phase + whatever's locked into star
+  particles) must never decrease across the run — metals are only ever
+  created by stellar enrichment in this code, never destroyed.
+- **Dust** (only meaningful if `Config.sh` has `DUST` enabled; skipped
+  with a message otherwise): every gas cell's `DustMass` must satisfy
+  `0 <= DustMass <= GasMetals` at every snapshot — dust is a subset of
+  the metal budget it condensed from.
+
+Not a reference-solution comparison like the `test.sh`-integrated
+examples' `check.py` scripts — there's no golden run for this example
+(external IC/data dependencies), so these are invariant/sanity checks
+only, meant to catch an obviously broken run (mass appearing from
+nowhere, dust exceeding its metal budget) rather than verify exact
+physics.
+
 ## Known gaps / things to revisit
 
 - `InitMetallicityinSolar = 0.1` (required by `METALS`) is an assumed
@@ -147,5 +172,3 @@ reader — see the script's docstring for the full set of options
   `SN_HostShellSweepFrac=0.5`, `IMF=0` for Kroupa) are literature-typical
   defaults, not values validated against this fork's implementation —
   treat as a starting point.
-- No `check.py`/reference data, unlike the `test.sh`-integrated examples —
-  there's nothing here yet to catch a silent regression automatically.

--- a/examples/agora_disc_star_formation_3d/README.md
+++ b/examples/agora_disc_star_formation_3d/README.md
@@ -157,7 +157,7 @@ python check.py .
 ```
 
 Run from this directory (or pass whatever directory contains your
-`output/`). Two checks, printed per-snapshot and summarized pass/fail:
+`output/`). Five checks, printed per-snapshot and summarized pass/fail:
 
 - **Metals**: total metal mass (gas-phase + whatever's locked into star
   particles) must never decrease across the run — metals are only ever
@@ -166,6 +166,22 @@ Run from this directory (or pass whatever directory contains your
   with a message otherwise): every gas cell's `DustMass` must satisfy
   `0 <= DustMass <= GasMetals` at every snapshot — dust is a subset of
   the metal budget it condensed from.
+- **Star formation**: number of star particles must never decrease —
+  stars are only "deactivated" when dead, never removed from the
+  particle list.
+- **Star-forming gas** (informational, no hard pass/fail beyond "did it
+  compute"): mass and mass fraction of gas above the `AGORA_SF` density
+  threshold and below the temperature threshold, using thresholds read
+  from each snapshot's own embedded `/Parameters` group. Temperature
+  uses the same non-Grackle mean-molecular-weight fallback the C code
+  itself uses when `USE_GRACKLE` is off — an approximation of the real
+  (Grackle-chemistry-dependent) trigger condition, not an exact
+  reproduction, so treat this as trend monitoring rather than a precise
+  reconstruction of what actually decided each cell's eligibility.
+- **Stellar spatial extent** (informational, `WARN` rather than `FAIL`):
+  min/median/max cylindrical radius and `|z|`-height of star particles
+  relative to the box centre, flagged if a star approaches the box edge
+  (a sign of numerical ejection rather than staying in the disc).
 
 Not a reference-solution comparison like the `test.sh`-integrated
 examples' `check.py` scripts — there's no golden run for this example

--- a/examples/agora_disc_star_formation_3d/agora_disc_diagnostics.py
+++ b/examples/agora_disc_star_formation_3d/agora_disc_diagnostics.py
@@ -8,6 +8,16 @@ snapshots. Profiles from multiple snapshots are overlaid on a single set of
 axes; the smoothed-grid projection plot is always produced, one image per
 snapshot.
 
+Also reads the gas cells' metal mass (`PassiveScalars`, METALS_INDEX==0)
+and, if present, dust mass (`DustMass`, only written when the run was
+built with `DUST`) directly from PartType0 -- these are gas-only Arepo
+scalar fields, independent of whatever `--ptype` is requested for the
+main mass/kinematic profiles. For each snapshot this produces the same
+smoothed-grid XY/XZ/YZ projection plots as gas mass gets, plus a second
+overlaid-profile figure of metal and dust surface density vs. radius,
+mirroring the gas surface-density panel. The dust grid/profile is skipped
+(with a log message, not an error) if the snapshot has no DustMass field.
+
 Dependencies
 ------------
 If the `analysistools` package is installed, it is used directly
@@ -27,10 +37,15 @@ Examples:
     python agora_disc_diagnostics.py --snapshot snap_200.hdf5
 
     # multiple snapshots, overlaid profiles + per-snapshot grid images
+    # (gas, metals, and dust -- dust grid/profile auto-skipped if the run
+    # has no DustMass field)
     python agora_disc_diagnostics.py \
         --snapshot snap_100.hdf5 snap_150.hdf5 snap_200.hdf5 \
         --output disc_profiles.png \
         --grid-output "disc_grid_{name}.png" \
+        --metals-grid-output "disc_grid_metals_{name}.png" \
+        --dust-grid-output "disc_grid_dust_{name}.png" \
+        --metals-dust-output "disc_metals_dust_profiles.png" \
         --mask-radius 15 \
         --save-data disc_profiles.npz
 """
@@ -443,6 +458,36 @@ def read_snapshot_h5py(path, ptype):
     return pos, vel, mass, boxsize
 
 
+def read_gas_scalars_h5py(path):
+    """Read gas (PartType0) positions, mass, metal mass, and dust mass (if
+    present) directly from an Arepo HDF5 snapshot. Always reads via h5py,
+    even when analysistools is available, since PassiveScalars/DustMass are
+    Arepo-specific fields not exposed by a generic snapshot reader.
+
+    Returns (pos, mass, metal_mass, dust_mass); dust_mass is None if the
+    run wasn't built with DUST.
+    """
+    import h5py
+
+    with h5py.File(path, "r") as f:
+        if "PartType0" not in f:
+            raise KeyError(f"'PartType0' not present in {path}")
+        grp = f["PartType0"]
+
+        pos = grp["Coordinates"][()]
+        mass = grp["Masses"][()]
+
+        metal_mass = None
+        if "PassiveScalars" in grp:
+            passive_scalars = grp["PassiveScalars"][()]
+            metallicity = passive_scalars[:, 0] if passive_scalars.ndim == 2 else passive_scalars
+            metal_mass = metallicity * mass
+
+        dust_mass = grp["DustMass"][()] if "DustMass" in grp else None
+
+    return pos, mass, metal_mass, dust_mass
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Compute AGORA disc diagnostics from one or more Arepo snapshots"
@@ -486,10 +531,27 @@ def parse_args():
     )
     parser.add_argument(
         "--grid-output", default="disc_grid_{name}.png",
-        help="Output figure template for the per-snapshot grid projection. "
+        help="Output figure template for the per-snapshot gas mass grid projection. "
              "May contain {name} (snapshot filename stem) and/or {index}. "
              "If neither placeholder is present, the snapshot name is appended "
              "automatically so multiple snapshots don't overwrite each other.",
+    )
+    parser.add_argument(
+        "--metals-grid-output", default="disc_grid_metals_{name}.png",
+        help="Output figure template for the per-snapshot gas metal-mass grid "
+             "projection. Same {name}/{index} substitution as --grid-output.",
+    )
+    parser.add_argument(
+        "--dust-grid-output", default="disc_grid_dust_{name}.png",
+        help="Output figure template for the per-snapshot gas dust-mass grid "
+             "projection. Same {name}/{index} substitution as --grid-output. "
+             "Skipped if the snapshot has no DustMass field.",
+    )
+    parser.add_argument(
+        "--metals-dust-output", default="disc_metals_dust_profiles.png",
+        help="Output figure for overlaid metal and dust surface-density radial "
+             "profiles (mirrors --output for gas). Dust panel is omitted if no "
+             "snapshot has a DustMass field.",
     )
     parser.add_argument("--save-data", default=None, help="Optional .npz path to save the computed profiles (all snapshots, one file)")
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
@@ -546,19 +608,25 @@ def load_particles(snapshot_path, args):
     return pos, vel, mass, centre
 
 
-def apply_mask(pos, vel, mass, centre, args):
-    """Restrict to a cylindrical region around the centre. Optional: improves
-    speed and avoids off-disc contamination when enabled via --mask-radius."""
+def compute_mask(pos, centre, args):
+    """Boolean mask selecting particles within a cylindrical region around
+    the centre (radius --mask-radius, half-height --mask-zheight). Returns
+    an all-True mask if --mask-radius is unset."""
     if args.mask_radius is None:
-        return pos, vel, mass
+        return np.ones(len(pos), dtype=bool)
 
     dxy = pos[:, :2] - centre[:2]
     r = np.hypot(dxy[:, 0], dxy[:, 1])
     dz = np.abs(pos[:, 2] - centre[2])
 
-    mask = (r <= args.mask_radius) & (dz <= args.mask_zheight)
-    log.info("Mask kept %d / %d particles", mask.sum(), len(pos))
+    return (r <= args.mask_radius) & (dz <= args.mask_zheight)
 
+
+def apply_mask(pos, vel, mass, centre, args):
+    """Restrict to a cylindrical region around the centre. Optional: improves
+    speed and avoids off-disc contamination when enabled via --mask-radius."""
+    mask = compute_mask(pos, centre, args)
+    log.info("Mask kept %d / %d particles", mask.sum(), len(pos))
     return pos[mask], vel[mask], mass[mask]
 
 
@@ -581,6 +649,21 @@ def compute_profiles(pos, vel, mass, centre, args):
     sigmaz = profiler.vertical_velocity_dispersion(pos, vel, centre, args.rmin, inner_rmax, nbins=inner_nbins)
 
     return sigma, hz, sigmaz
+
+
+def compute_metals_dust_profiles(pos, metal_mass, dust_mass, centre, args):
+    """Radial surface-density profiles for gas metal mass and (if present)
+    dust mass, mirroring compute_profiles' gas surface-density panel.
+    pos/metal_mass/dust_mass are expected already masked (see apply_mask)."""
+    profiler = ProfileTools(numbins=args.nbins)
+
+    sigma_metals = profiler.surface_density(pos, metal_mass, centre, args.rmin, args.rmax)
+
+    sigma_dust = None
+    if dust_mass is not None:
+        sigma_dust = profiler.surface_density(pos, dust_mass, centre, args.rmin, args.rmax)
+
+    return sigma_metals, sigma_dust
 
 
 def plot_overlaid_profiles(results, output):
@@ -610,10 +693,44 @@ def plot_overlaid_profiles(results, output):
     plt.close(fig)
     log.info("Saved %s", output)
 
-def plot_grid(pos, mass, centre, args, output_path):
-    """Smoothed-grid projection plot for a single snapshot. Always run,
-    regardless of --mask-radius (uses the full particle set, like the
-    source notebook)."""
+
+def plot_metals_dust_profiles(results, output):
+    """results: list of dicts with keys name, sigma_metals, sigma_dust
+    (sigma_dust may be None for a given snapshot). Mirrors
+    plot_overlaid_profiles' gas surface-density panel."""
+    have_dust = any(res["sigma_dust"] is not None for res in results)
+
+    ncols = 2 if have_dust else 1
+    fig, axes = plt.subplots(1, ncols, figsize=(5 * ncols + 2, 4))
+    axes = np.atleast_1d(axes)
+
+    for res in results:
+        axes[0].plot(res["sigma_metals"]["r"], res["sigma_metals"]["density"], label=res["name"])
+        if have_dust and res["sigma_dust"] is not None:
+            axes[1].plot(res["sigma_dust"]["r"], res["sigma_dust"]["density"], label=res["name"])
+
+    axes[0].set_xlabel("R [kpc]")
+    axes[0].set_ylabel(r"$\Sigma_{\rm metals}(R)$")
+    axes[0].set_yscale("log")
+    if len(results) > 1:
+        axes[0].legend(fontsize="small")
+
+    if have_dust:
+        axes[1].set_xlabel("R [kpc]")
+        axes[1].set_ylabel(r"$\Sigma_{\rm dust}(R)$")
+        axes[1].set_yscale("log")
+
+    fig.tight_layout()
+    fig.savefig(output, dpi=200)
+    plt.close(fig)
+    log.info("Saved %s", output)
+
+
+def plot_grid(pos, values, centre, args, output_path, title=None):
+    """Smoothed-grid projection plot for a single quantity/snapshot. Always
+    run on the full particle set (regardless of --mask-radius), like the
+    source notebook. `values` is whatever per-particle quantity is being
+    projected (mass, metal mass, or dust mass)."""
     gridding = GriddingTools()
 
     lzgrid = args.lzgrid if args.lzgrid is not None else args.lgrid / 4
@@ -632,14 +749,19 @@ def plot_grid(pos, mass, centre, args, output_path):
 
     smoothed_grid = gridding.smooth_to_grid(
         positions=pos[box_mask],
-        values=mass[box_mask],
+        values=values[box_mask],
         grid_size=grid_size,
         grid_limits=grid_limits,
         method="Gaussian",
         sigma=args.smooth_sigma,
     )
 
-    fig, _ = gridding.plot_3d_projections(smoothed_grid, grid_limits, projection="mean")
+    try:
+        fig, _ = gridding.plot_3d_projections(smoothed_grid, grid_limits, projection="mean", title=title)
+    except TypeError:
+        # the installed analysistools.GriddingTools.plot_3d_projections may not
+        # accept `title` -- degrade gracefully rather than failing the run
+        fig, _ = gridding.plot_3d_projections(smoothed_grid, grid_limits, projection="mean")
     fig.savefig(output_path, dpi=200)
     plt.close(fig)
     log.info("Saved %s", output_path)
@@ -655,6 +777,12 @@ def save_data(results, path):
         arrays[f"{name}__hz_scale_height"] = res["hz"]["scale_height"]
         arrays[f"{name}__sigmaz_r"] = res["sigmaz"]["r"]
         arrays[f"{name}__sigmaz_sigma_z"] = res["sigmaz"]["sigma_z"]
+        if res.get("sigma_metals") is not None:
+            arrays[f"{name}__sigma_metals_r"] = res["sigma_metals"]["r"]
+            arrays[f"{name}__sigma_metals_density"] = res["sigma_metals"]["density"]
+        if res.get("sigma_dust") is not None:
+            arrays[f"{name}__sigma_dust_r"] = res["sigma_dust"]["r"]
+            arrays[f"{name}__sigma_dust_density"] = res["sigma_dust"]["density"]
     np.savez(path, **arrays)
     log.info("Saved profile data to %s", path)
 
@@ -676,14 +804,55 @@ def main():
         pos, vel, mass, centre = load_particles(snapshot_path, args)
 
         grid_out = format_output_path(args.grid_output, name, index)
-        plot_grid(pos, mass, centre, args, grid_out)
+        plot_grid(pos, mass, centre, args, grid_out, title=f"Gas mass ({name})")
+
+        # Gas-only metal/dust scalars, independent of --ptype (metals/dust
+        # only exist on PartType0). Reused for both the grid projections
+        # (unmasked, mirroring the gas mass grid) and the radial surface
+        # density profiles (masked, mirroring the gas sigma profile).
+        try:
+            gas_pos, gas_mass, metal_mass, dust_mass = read_gas_scalars_h5py(snapshot_path)
+        except (OSError, IOError, KeyError) as exc:
+            log.error("Could not read gas scalars from '%s': %s", snapshot_path, exc)
+            sys.exit(1)
+
+        sigma_metals = sigma_dust = None
+
+        if metal_mass is not None:
+            metals_grid_out = format_output_path(args.metals_grid_output, name, index)
+            plot_grid(gas_pos, metal_mass, centre, args, metals_grid_out, title=f"Metal mass ({name})")
+        else:
+            log.warning("No PassiveScalars field in %s -- skipping metals grid/profile", snapshot_path)
+
+        if dust_mass is not None:
+            dust_grid_out = format_output_path(args.dust_grid_output, name, index)
+            plot_grid(gas_pos, dust_mass, centre, args, dust_grid_out, title=f"Dust mass ({name})")
+        else:
+            log.info("No DustMass field in %s -- skipping dust grid/profile (run not built with DUST?)", snapshot_path)
+
+        if metal_mass is not None:
+            gas_mask = compute_mask(gas_pos, centre, args)
+            gas_pos_m = gas_pos[gas_mask]
+            metal_mass_m = metal_mass[gas_mask]
+            dust_mass_m = dust_mass[gas_mask] if dust_mass is not None else None
+            sigma_metals, sigma_dust = compute_metals_dust_profiles(
+                gas_pos_m, metal_mass_m, dust_mass_m, centre, args
+            )
 
         pos_m, vel_m, mass_m = apply_mask(pos, vel, mass, centre, args)
         sigma, hz, sigmaz = compute_profiles(pos_m, vel_m, mass_m, centre, args)
 
-        results.append({"name": name, "sigma": sigma, "hz": hz, "sigmaz": sigmaz})
+        results.append({
+            "name": name, "sigma": sigma, "hz": hz, "sigmaz": sigmaz,
+            "sigma_metals": sigma_metals, "sigma_dust": sigma_dust,
+        })
 
     plot_overlaid_profiles(results, args.output)
+
+    if any(res["sigma_metals"] is not None for res in results):
+        plot_metals_dust_profiles(results, args.metals_dust_output)
+    else:
+        log.warning("No metals data in any snapshot -- skipping %s", args.metals_dust_output)
 
     if args.save_data:
         save_data(results, args.save_data)

--- a/examples/agora_disc_star_formation_3d/check.py
+++ b/examples/agora_disc_star_formation_3d/check.py
@@ -1,0 +1,161 @@
+""" @package ./examples/agora_disc_star_formation_3d/check.py
+Sanity checks on metal and dust conservation/invariants across the
+snapshots of an agora_disc_star_formation_3d run.
+
+Not a reference-solution comparison (no golden run exists for this
+example -- it depends on downloaded external data, see get_ics.sh /
+get_tables.sh) and not wired into test.sh for the same reason. Run by
+hand after a run:
+
+    python check.py <simulation_directory>
+
+where <simulation_directory> contains output/snap_*.hdf5.
+
+Two checks:
+
+  Metals check
+    Total metal mass (gas-phase + whatever's locked into star particles)
+    must never decrease over the run, within a small floating-point
+    tolerance -- metals are created by stellar enrichment and never
+    destroyed anywhere in this code.
+
+  Dust check (only if the run was built with DUST; skipped with a
+  warning otherwise)
+    Every gas cell's DustMass must satisfy the module's core physical
+    invariant at every snapshot: 0 <= DustMass <= (gas-phase metal mass
+    in that cell). Dust is a subset of the metal budget it condensed
+    from, so it can never be negative or exceed it.
+
+Exits 0 if both checks pass (or the dust check is skipped because the
+run has no DustMass field), 1 otherwise.
+"""
+
+import glob
+import os
+import sys
+
+import h5py
+import numpy as np
+
+FloatType = np.float64
+
+
+def find_snapshots(simulation_directory):
+    directory = os.path.join(simulation_directory, "output")
+    files = sorted(glob.glob(os.path.join(directory, "snap_*.hdf5")))
+    if not files:
+        print("check.py: no snap_*.hdf5 files found in " + directory)
+        sys.exit(1)
+    return files
+
+
+def gas_metal_mass(f):
+    """Metal mass per gas cell (METALS_INDEX == 0 in PassiveScalars)."""
+    mass = np.array(f["PartType0"]["Masses"], dtype=FloatType)
+    passive_scalars = np.array(f["PartType0"]["PassiveScalars"], dtype=FloatType)
+    metallicity = passive_scalars[:, 0]
+    return metallicity * mass, mass
+
+
+def star_metal_mass(f):
+    """Metal mass locked into star particles, if any exist yet."""
+    if "PartType4" not in f or "Metallicity" not in f["PartType4"]:
+        return 0.0
+    mass = np.array(f["PartType4"]["Masses"], dtype=FloatType)
+    metallicity = np.array(f["PartType4"]["Metallicity"], dtype=FloatType)
+    return float(np.sum(metallicity * mass))
+
+
+def check_metals(snapshot_files):
+    print("--- metals check ---")
+    total_metal_mass = []
+    times = []
+    for filename in snapshot_files:
+        with h5py.File(filename, "r") as f:
+            metal_mass_per_cell, _ = gas_metal_mass(f)
+            total = float(np.sum(metal_mass_per_cell)) + star_metal_mass(f)
+            total_metal_mass.append(total)
+            times.append(float(f["Header"].attrs["Time"]))
+
+    total_metal_mass = np.array(total_metal_mass)
+    times = np.array(times)
+
+    ok = True
+    # allow a tiny relative tolerance for floating-point noise, but total
+    # metal mass must not meaningfully decrease between snapshots
+    rel_tol = 1e-6
+    for i in range(1, len(total_metal_mass)):
+        prev, cur = total_metal_mass[i - 1], total_metal_mass[i]
+        if cur < prev * (1.0 - rel_tol):
+            print(
+                "FAIL: total metal mass decreased from %.6e (t=%.6g) to %.6e (t=%.6g)"
+                % (prev, times[i - 1], cur, times[i])
+            )
+            ok = False
+
+    for t, m in zip(times, total_metal_mass):
+        print("  t=%.6g  total metal mass=%.6e" % (t, m))
+
+    if ok:
+        print("PASS: total metal mass is non-decreasing across all snapshots")
+    return ok
+
+
+def check_dust(snapshot_files):
+    print("--- dust check ---")
+    with h5py.File(snapshot_files[0], "r") as f:
+        if "DustMass" not in f["PartType0"]:
+            print("SKIP: no DustMass field in snapshots (run was not built with DUST)")
+            return True
+
+    ok = True
+    tol = 1e-20  # absolute tolerance, code mass units
+    for filename in snapshot_files:
+        with h5py.File(filename, "r") as f:
+            time = float(f["Header"].attrs["Time"])
+            dust_mass = np.array(f["PartType0"]["DustMass"], dtype=FloatType)
+            metal_mass_per_cell, _ = gas_metal_mass(f)
+
+            n_negative = int(np.sum(dust_mass < -tol))
+            n_exceeds = int(np.sum(dust_mass > metal_mass_per_cell + tol))
+
+            if n_negative > 0:
+                print("FAIL: t=%.6g: %d cells have DustMass < 0" % (time, n_negative))
+                ok = False
+            if n_exceeds > 0:
+                print(
+                    "FAIL: t=%.6g: %d cells have DustMass > GasMetals (dust exceeds its own metal budget)"
+                    % (time, n_exceeds)
+                )
+                ok = False
+
+            print(
+                "  t=%.6g  total dust mass=%.6e  nonzero cells=%d/%d"
+                % (time, float(np.sum(dust_mass)), int(np.sum(dust_mass > 0)), len(dust_mass))
+            )
+
+    if ok:
+        print("PASS: 0 <= DustMass <= GasMetals holds in every cell, every snapshot")
+    return ok
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: python check.py <simulation_directory>")
+        sys.exit(1)
+
+    simulation_directory = str(sys.argv[1])
+    print(
+        "examples/agora_disc_star_formation_3d/check.py: checking simulation output in directory "
+        + simulation_directory
+    )
+
+    snapshot_files = find_snapshots(simulation_directory)
+
+    metals_ok = check_metals(snapshot_files)
+    dust_ok = check_dust(snapshot_files)
+
+    if metals_ok and dust_ok:
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/examples/agora_disc_star_formation_3d/check.py
+++ b/examples/agora_disc_star_formation_3d/check.py
@@ -1,6 +1,6 @@
 """ @package ./examples/agora_disc_star_formation_3d/check.py
-Sanity checks on metal and dust conservation/invariants across the
-snapshots of an agora_disc_star_formation_3d run.
+Sanity checks and monitoring across the snapshots of an
+agora_disc_star_formation_3d run.
 
 Not a reference-solution comparison (no golden run exists for this
 example -- it depends on downloaded external data, see get_ics.sh /
@@ -11,7 +11,7 @@ hand after a run:
 
 where <simulation_directory> contains output/snap_*.hdf5.
 
-Two checks:
+Two pass/fail invariant checks:
 
   Metals check
     Total metal mass (gas-phase + whatever's locked into star particles)
@@ -26,8 +26,38 @@ Two checks:
     in that cell). Dust is a subset of the metal budget it condensed
     from, so it can never be negative or exceed it.
 
-Exits 0 if both checks pass (or the dust check is skipped because the
-run has no DustMass field), 1 otherwise.
+Plus three monitoring checks, printed per-snapshot (mostly informational,
+but each still fails on an obviously-broken run):
+
+  Star formation
+    Number of star particles per snapshot. Stars are never removed from
+    the particle list once formed in this code (only "deactivated" when
+    dead/low-mass -- see deactivate_star() in src/stars/star_update.c),
+    so this must be non-decreasing.
+
+  Star-forming gas
+    Mass and mass fraction of gas above the AGORA_SF density threshold
+    and below the temperature threshold (src/star_formation/sfr_AGORA.c's
+    sf_criteria()), i.e. eligible to form stars. Temperature is computed
+    with the same non-Grackle mean-molecular-weight fallback formula
+    sf_criteria() itself uses when USE_GRACKLE is off (mu = 4/(8-5*(1-XH)),
+    fully-ionized approximation) -- this is an approximation of the
+    actual (Grackle-chemistry-network-dependent) trigger condition used
+    at runtime, not an exact reproduction; treat as directional/trend
+    monitoring, not a precise reconstruction of the code's own decision.
+    Thresholds are read from each snapshot's own embedded /Parameters
+    group, not hardcoded.
+
+  Stellar spatial extent
+    Min/median/max cylindrical radius and |z|-height of star particles
+    relative to the box centre. Flagged (not hard-failed) if the maximum
+    radius approaches the box edge, which would indicate particles have
+    been numerically ejected rather than staying in the disc.
+
+Exits 0 if both pass/fail checks pass (dust check may be skipped), 1
+otherwise. The three monitoring checks print WARN rather than FAIL for
+anything short of a clear invariant violation, since "trend looks odd"
+isn't itself proof of a bug the way a metals/dust invariant violation is.
 """
 
 import glob
@@ -38,6 +68,11 @@ import h5py
 import numpy as np
 
 FloatType = np.float64
+
+PROTONMASS_CGS = 1.67262178e-24
+BOLTZMANN_CGS = 1.38065e-16
+HYDROGEN_MASSFRAC = 0.76
+GAMMA_MINUS1 = 2.0 / 3.0  # monatomic gas, gamma = 5/3
 
 
 def find_snapshots(simulation_directory):
@@ -139,6 +174,151 @@ def check_dust(snapshot_files):
     return ok
 
 
+def check_star_formation(snapshot_files):
+    print("--- star formation check ---")
+    counts = []
+    times = []
+    for filename in snapshot_files:
+        with h5py.File(filename, "r") as f:
+            n_stars = int(f["Header"].attrs["NumPart_Total"][4])
+            counts.append(n_stars)
+            times.append(float(f["Header"].attrs["Time"]))
+            print("  t=%.6g  number of stars=%d" % (times[-1], n_stars))
+
+    ok = True
+    for i in range(1, len(counts)):
+        if counts[i] < counts[i - 1]:
+            print(
+                "FAIL: number of stars decreased from %d (t=%.6g) to %d (t=%.6g) "
+                "-- stars should never be removed from the particle list"
+                % (counts[i - 1], times[i - 1], counts[i], times[i])
+            )
+            ok = False
+
+    if ok:
+        print("PASS: number of stars is non-decreasing across all snapshots")
+    return ok
+
+
+def sf_thresholds(f):
+    """Read NumberDensThreshold/TemperatureThreshold from the snapshot's own
+    embedded /Parameters group (not hardcoded). Returns None if not present
+    (e.g. the run wasn't built with AGORA_SF)."""
+    if "Parameters" not in f:
+        return None
+    attrs = f["Parameters"].attrs
+    if "NumberDensThreshold" not in attrs or "TemperatureThreshold" not in attrs:
+        return None
+    return float(attrs["NumberDensThreshold"]), float(attrs["TemperatureThreshold"])
+
+
+def gas_number_density_and_temperature(f):
+    """Approximate physical number density [cm^-3] and temperature [K] per
+    gas cell, using the same formulas as sf_criteria() in
+    src/star_formation/sfr_AGORA.c, but with the non-Grackle mean molecular
+    weight fallback (mu = 4/(8-5*(1-XH))) regardless of whether the run
+    actually used USE_GRACKLE -- an approximation of the true
+    chemistry-network-dependent mu, not an exact match. See module
+    docstring."""
+    header = f["Header"].attrs
+    unit_length_cm = float(header["UnitLength_in_cm"])
+    unit_mass_g = float(header["UnitMass_in_g"])
+    unit_velocity_cm_s = float(header["UnitVelocity_in_cm_per_s"])
+    unit_density_cgs = unit_mass_g / unit_length_cm ** 3
+
+    density = np.array(f["PartType0"]["Density"], dtype=FloatType)
+    utherm = np.array(f["PartType0"]["InternalEnergy"], dtype=FloatType)
+
+    mu = 4.0 / (8.0 - 5.0 * (1.0 - HYDROGEN_MASSFRAC))
+
+    number_density = (density * unit_density_cgs) / mu / PROTONMASS_CGS
+    temperature = (
+        utherm * unit_velocity_cm_s ** 2 * mu * PROTONMASS_CGS * GAMMA_MINUS1 / BOLTZMANN_CGS
+    )
+
+    return number_density, temperature
+
+
+def check_sf_gas_fraction(snapshot_files):
+    print("--- star-forming gas check (approximate, see module docstring) ---")
+    with h5py.File(snapshot_files[0], "r") as f:
+        thresholds = sf_thresholds(f)
+        if thresholds is None:
+            print("SKIP: no NumberDensThreshold/TemperatureThreshold in /Parameters "
+                  "(run was not built with AGORA_SF)")
+            return True
+    number_dens_threshold, temperature_threshold = thresholds
+    print(
+        "  thresholds from snapshot: NumberDensThreshold=%.6g cm^-3, TemperatureThreshold=%.6g K"
+        % (number_dens_threshold, temperature_threshold)
+    )
+
+    ok = True
+    for filename in snapshot_files:
+        with h5py.File(filename, "r") as f:
+            time = float(f["Header"].attrs["Time"])
+            mass = np.array(f["PartType0"]["Masses"], dtype=FloatType)
+            number_density, temperature = gas_number_density_and_temperature(f)
+
+            eligible = (number_density >= number_dens_threshold) & (temperature <= temperature_threshold)
+            eligible_mass = float(np.sum(mass[eligible]))
+            total_mass = float(np.sum(mass))
+            fraction = eligible_mass / total_mass if total_mass > 0 else float("nan")
+
+            if not np.isfinite(fraction):
+                print("FAIL: t=%.6g: star-forming gas fraction is not finite" % time)
+                ok = False
+
+            print(
+                "  t=%.6g  star-forming-eligible gas mass=%.6e (%.4g%% of gas mass), cells=%d/%d"
+                % (time, eligible_mass, 100.0 * fraction, int(np.sum(eligible)), len(mass))
+            )
+
+    if ok:
+        print("PASS: star-forming gas fraction computed successfully at every snapshot "
+              "(informational -- no expected trend asserted)")
+    return ok
+
+
+def check_stellar_extent(snapshot_files):
+    print("--- stellar spatial extent check ---")
+    ok = True
+    for filename in snapshot_files:
+        with h5py.File(filename, "r") as f:
+            time = float(f["Header"].attrs["Time"])
+            boxsize = float(np.asarray(f["Header"].attrs["BoxSize"]).reshape(-1)[0])
+            centre = boxsize / 2.0
+
+            if "PartType4" not in f or int(f["Header"].attrs["NumPart_Total"][4]) == 0:
+                print("  t=%.6g  no star particles yet" % time)
+                continue
+
+            pos = np.array(f["PartType4"]["Coordinates"], dtype=FloatType)
+            dxy = pos[:, :2] - centre
+            r = np.hypot(dxy[:, 0], dxy[:, 1])
+            z = np.abs(pos[:, 2] - centre)
+
+            print(
+                "  t=%.6g  R [kpc]: min=%.3g median=%.3g max=%.3g | |z| [kpc]: min=%.3g median=%.3g max=%.3g"
+                % (time, r.min(), np.median(r), r.max(), z.min(), np.median(z), z.max())
+            )
+
+            # loose sanity bound: flag (not hard-fail) if stars approach the
+            # box edge, which would indicate numerical ejection rather than
+            # staying in the disc
+            edge_fraction = 0.9
+            if r.max() > edge_fraction * (boxsize / 2.0) or z.max() > edge_fraction * (boxsize / 2.0):
+                print(
+                    "WARN: t=%.6g: a star particle is within %.0f%% of the box edge "
+                    "(R_max=%.3g, |z|_max=%.3g, box half-size=%.3g) -- check for numerical ejection"
+                    % (time, 100.0 * edge_fraction, r.max(), z.max(), boxsize / 2.0)
+                )
+
+    print("PASS: stellar spatial extent computed successfully at every snapshot with stars "
+          "(informational, WARN only on apparent ejection)")
+    return ok
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("usage: python check.py <simulation_directory>")
@@ -154,8 +334,11 @@ if __name__ == "__main__":
 
     metals_ok = check_metals(snapshot_files)
     dust_ok = check_dust(snapshot_files)
+    stars_ok = check_star_formation(snapshot_files)
+    sf_gas_ok = check_sf_gas_fraction(snapshot_files)
+    extent_ok = check_stellar_extent(snapshot_files)
 
-    if metals_ok and dust_ok:
+    if metals_ok and dust_ok and stars_ok and sf_gas_ok and extent_ok:
         sys.exit(0)
     else:
         sys.exit(1)

--- a/examples/dust_isolated_disk_3d/Config.sh
+++ b/examples/dust_isolated_disk_3d/Config.sh
@@ -1,0 +1,82 @@
+#!/bin/bash        	# this line only there to enable syntax highlighting in this file
+
+#########################################################
+#  Enable/Disable compile-time options as needed        #
+#  examples/dust_isolated_disk_3d/Config.sh              #
+#########################################################
+#
+# Flag combination mirrors Config_AGORA.sh (the only config in this repo
+# that already enables METALS + STARS + WINDS + SUPERNOVAE together) plus
+# DUST. This example has NO paired initial-conditions file -- see README.md
+# in this directory. Config.sh scaffolding only, per the Phase 1
+# implementation plan.
+
+#--------------------------------------- SOLAS additions
+
+#--------------------------------------- Metal parameters
+METALS                 # Advect all metals, ie metal mass fraction, as a PASSIVE_SCALARS
+# Do NOT also set PASSIVE_SCALARS=N here: it is computed automatically from
+# METALS_NUMBER + DUST_NUMBER (see src/main/allvars.h) once DUST is enabled.
+
+#--------------------------------------- Dust parameters
+DUST                    # Phase 1: single-species dust mass (SN-channel production/destruction, growth, sputtering)
+
+#--------------------------------------- Cooling parameters
+USE_GRACKLE
+GRACKLE_CHEMISTRY=3
+
+#--------------------------------------- Star Formation options
+AGORA_SF                # Agora based SF
+
+#--------------------------------------- Star options
+STARS                   # General stars framework flag
+
+STAR_PARTICLES=1        # Star particles model flag: set to 0, 1 for massive star particles, set to 2 for resolved individual stars
+
+WINDS                   # Only winds
+SUPERNOVAE               # Only supernovae -- required by DUST (Phase 1 production/destruction is SN-channel only)
+
+#--------------------------------------- Arepo public
+
+#--------------------------------------- Mesh motion and regularization; default: moving mesh
+REGULARIZE_MESH_CM_DRIFT      # Mesh regularization; Move mesh generating point towards center of mass to make cells rounder.
+REGULARIZE_MESH_CM_DRIFT_USE_SOUNDSPEED  # Limit mesh regularization speed by local sound speed
+REGULARIZE_MESH_FACE_ANGLE    # Use maximum face angle as roundness criterion in mesh regularization
+
+#--------------------------------------- Refinement and derefinement; default: no refinement/derefinement; criterion: target mass
+REFINEMENT_SPLIT_CELLS        # Refinement
+REFINEMENT_MERGE_CELLS        # Derefinement
+REFINEMENT_VOLUME_LIMIT       # Limit the volume of cells and the maximum volume difference between neighboring cels
+NODEREFINE_BACKGROUND_GRID    # Do not de-refine low-res gas cells in zoom simulations
+
+#--------------------------------------- non-standard phyiscs
+COOLING                       # Simple primordial cooling
+USE_SFR                       # Star formation model, turning dense gas into collisionless partices
+
+#--------------------------------------- Gravity treatment; default: no gravity
+SELFGRAVITY                   # gravitational intraction between simulation particles/cells
+HIERARCHICAL_GRAVITY          # use hierarchical splitting of the time integration of the gravity
+CELL_CENTER_GRAVITY           # uses geometric centers to calculate gravity of cells, only possible with HIERARCHICAL_GRAVITY
+GRAVITY_NOT_PERIODIC          # gravity is not treated periodically
+ALLOW_DIRECT_SUMMATION        # Performed direct summation instead of tree-based gravity if number of active particles < DIRECT_SUMMATION_THRESHOLD (= 3000 unless specified differently here)
+DIRECT_SUMMATION_THRESHOLD=500  # Overrides maximum number of active particles for which direct summation is performed instead of tree based calculation
+
+#--------------------------------------- Gravity softening
+NSOFTTYPES=4                  # Number of different softening values to which particle types can be mapped.
+MULTIPLE_NODE_SOFTENING       # If a tree node is to be used which is softened, this is done with the softenings of its different mass components
+ADAPTIVE_HYDRO_SOFTENING      # Adaptive softening of gas cells depending on their size
+
+#--------------------------------------- Time integration options
+TREE_BASED_TIMESTEPS          # non-local timestep criterion (take 'signal speed' into account)
+
+#--------------------------------------- Single/Double Precision
+DOUBLEPRECISION=1             # Mode of double precision: not defined: single; 1: full double precision 2: mixed, 3: mixed, fewer single precisions; unless short of memory, use 1.
+
+#--------------------------------------- output options
+PROCESS_TIMES_OF_OUTPUTLIST   # goes through times of output list prior to starting the simulaiton to ensure that outputs are written as close to the desired time as possible (as opposed to at next possible time if this flag is not active)
+HAVE_HDF5                     # needed when HDF5 I/O support is desired (recommended)
+
+#--------------------------------------- Testing and Debugging options
+DEBUG                         # enables core-dumps
+
+OVERRIDE_PEANOGRID_WARNING    # don't stop if peanogrid is not fine enough

--- a/examples/dust_isolated_disk_3d/README.md
+++ b/examples/dust_isolated_disk_3d/README.md
@@ -1,0 +1,53 @@
+# dust_isolated_disk_3d (scaffold only, no IC)
+
+This example exists to give the dust module's Phase 1 exit gate ("zero-rate
+run reproduces a non-dust run bit-for-bit", "total metal mass conserved,
+D/Z-Z trend matches Li et al. 2019") a `Config.sh`/`param.txt` pair to run
+against. **It ships with no initial conditions file and cannot be run as-is.**
+
+No example in this repository currently enables `STARS` + `SUPERNOVAE` +
+`WINDS` + `METALS` together (the flag combination `DUST` requires) with a
+paired IC -- `Config_AGORA.sh` has the right flags but no example directory,
+and `examples/galaxy_merger_star_formation_3d/` has an IC but uses the
+`EEOS_SF` star-formation model, which never turns on the `STARS`/mechanical-
+feedback framework at all. This directory's `Config.sh` mirrors
+`Config_AGORA.sh` plus `DUST`; `param.txt` mirrors
+`examples/galaxy_merger_star_formation_3d/param.txt`'s general run
+parameters plus the extra parameters `AGORA_SF`/`STAR_PARTICLES`/
+`STAR_FEEDBACK_ACTIVE`/`SUPERNOVAE`/`METALS`/`USE_GRACKLE` each require.
+
+## What you need to supply before this can run
+
+1. **`InitCondFile`** -- an isolated-disk (or similar idealized ISM) IC.
+   Whatever the group's standard isolated-galaxy/ISM-box setup is.
+2. **`GrackleDataFile`** -- the Grackle chemistry/cooling data file
+   (`CloudyData_UVB=...` etc.), not included in this repo.
+3. **`StarTablesFile`** -- the HDF5 stellar yield/feedback table consumed by
+   `load_star_tables()` (see `src/stars/star_tables.c`), not included in
+   this repo.
+4. Adjust `BoxSize`, `ReferenceGasPartMass`, `MeanVolume`, and the
+   softening lengths in `param.txt` to match whatever IC you supply --
+   the values currently in the file are copied from
+   `examples/galaxy_merger_star_formation_3d/param.txt` as placeholders,
+   not tuned for this setup.
+5. `SN_LeadTime`, `SN_HostShellSweepFrac`, `NumberDensThreshold`,
+   `TemperatureThreshold`, `StarFormationEfficiency`, and
+   `InitMetallicityinSolar` are all placeholder values -- tune them to
+   the group's usual choices for these parameters.
+
+## Running the Phase 1 exit-gate checks once an IC is in place
+
+- **Zero-rate bit-for-bit check**: build once with `DUST` on and once with
+  it off (same `Config.sh` otherwise); with the dust rate-law constants in
+  `src/dust/dust.h` all effectively zeroed out (e.g.
+  `DUST_SN_CONDENSATION_EFFICIENCY 0`), the two runs' gas-cell fields
+  (other than `DustMass` itself) should agree to machine precision.
+- **Metal mass conservation / D/Z-Z trend**: run with the module's default
+  rate-law constants and check `GasMetals` (gas-phase + dust-phase) is
+  conserved over the run, and that `DustMass / GasMetals` vs. metallicity
+  is qualitatively consistent with Li, Narayanan & Dave (2019)'s published
+  relation -- see the "Rate-law coefficient caveat" note in the Phase 1
+  implementation plan before treating the latter as a quantitative match.
+
+This example is deliberately **not** added to `test.sh`'s `TESTS` list,
+since it cannot run without the inputs above.

--- a/examples/dust_isolated_disk_3d/param.txt
+++ b/examples/dust_isolated_disk_3d/param.txt
@@ -1,0 +1,127 @@
+%---- Relevant files
+InitCondFile                            ./REPLACE_ME_ics           % no IC shipped with this example -- see README.md
+OutputDir                               ./output
+SnapshotFileBase                        snap
+OutputListFilename                      ./output_list.txt
+
+%---- File formats
+ICFormat                                3
+SnapFormat                              3
+
+%---- CPU-time limits
+TimeLimitCPU                            93000
+CpuTimeBetRestartFile                   12000
+ResubmitOn                              0
+ResubmitCommand                         my-scriptfile
+
+%----- Memory alloction
+MaxMemSize                              2500
+
+%---- Caracteristics of run
+TimeBegin                               0.0
+TimeMax                                 3.0            % End of the simulation -- adjust to the supplied IC
+
+%---- Basic code options that set the type of simulation
+ComovingIntegrationOn                   0
+PeriodicBoundariesOn                    0
+CoolingOn                               1
+StarformationOn                         1
+
+%---- Cosmological parameters (non-cosmological run; set for completeness)
+Omega0                                  0.0
+OmegaLambda                             0.0
+OmegaBaryon                             0.0
+HubbleParam                             0.6774
+BoxSize                                 649.201        % adjust to the supplied IC
+
+%---- Output frequency and output parameters
+OutputListOn                            1
+TimeBetSnapshot                         0.0
+TimeOfFirstSnapshot                     0.0
+TimeBetStatistics                       0.0234375
+NumFilesPerSnapshot                     1
+NumFilesWrittenInParallel               1
+
+%---- Accuracy of time integration
+TypeOfTimestepCriterion                 0
+ErrTolIntAccuracy                       0.012
+CourantFac                              0.3
+MaxSizeTimestep                         0.0234375
+MinSizeTimestep                         2.0e-8
+
+%---- Treatment of empty space and temperature limits
+InitGasTemp                             244.8095
+MinGasTemp                              5.0
+MinimumDensityOnStartUp                 1.0e-10
+LimitUBelowThisDensity                  0.0
+LimitUBelowCertainDensityToThisValue    0.0
+MinEgySpec                              0.0
+
+%---- Tree algorithm, force accuracy, domain update frequency
+TypeOfOpeningCriterion                  1
+ErrTolTheta                             0.7
+ErrTolForceAcc                          0.0025
+MultipleDomains                         8
+TopNodeFactor                           2.5
+ActivePartFracForNewDomainDecomp        0.01
+
+%---- Initial density estimate
+DesNumNgb                               64
+MaxNumNgbDeviation                      4
+
+%---- System of units
+UnitLength_in_cm                        3.085678e21    %  1.0 kpc
+UnitMass_in_g                           1.989e43       %  1.0e10 solar masses
+UnitVelocity_in_cm_per_s                1e5            %  1 km/sec
+GravityConstantInternal                 0
+
+%---- Gravitational softening lengths
+SofteningComovingType0                  2.0
+SofteningComovingType1                  2.0
+
+SofteningMaxPhysType0                   2.0
+SofteningMaxPhysType1                   2.0
+
+GasSoftFactor                           2.5
+
+SofteningTypeOfPartType0                0
+SofteningTypeOfPartType1                1
+SofteningTypeOfPartType2                1
+SofteningTypeOfPartType3                1
+SofteningTypeOfPartType4                1
+SofteningTypeOfPartType5                1
+
+MinimumComovingHydroSoftening           1.0
+AdaptiveHydroSofteningSpacing           1.2
+
+%----- Mesh regularization options
+CellShapingSpeed                        0.5
+CellMaxAngleFactor                      2.25
+ReferenceGasPartMass                    9.76211e-05    % adjust to the supplied IC's gas particle mass
+TargetGasMassFactor                     1
+RefinementCriterion                     1
+DerefinementCriterion                   1
+MeanVolume                              66800.2        % adjust to the supplied IC
+MaxVolumeDiff                           10
+MinVolume                               1
+MaxVolume                               1.0e9
+
+%---- Metals (METALS)
+InitMetallicityinSolar                  0.1
+
+%---- Cooling (COOLING, USE_GRACKLE)
+TreecoolFile                            ./TREECOOL_ep
+GrackleDataFile                         ./REPLACE_ME_grackle_data_file  % see README.md
+
+%---- Star formation (AGORA_SF)
+NumberDensThreshold                     10.0           % cm^-3
+TemperatureThreshold                    1e4            % K
+StarFormationEfficiency                 0.02
+
+%---- Stars (STAR_PARTICLES)
+IMF                                     0
+
+%---- Star feedback (STAR_FEEDBACK_ACTIVE / WINDS / SUPERNOVAE)
+StarTablesFile                          ./REPLACE_ME_star_tables.hdf5   % see README.md
+SN_LeadTime                             1.0e-3         % internal time units (TREE_BASED_TIMESTEPS + SUPERNOVAE)
+SN_HostShellSweepFrac                   0.5            % fraction of the Kim & Ostriker shell mass swept from the host cell

--- a/src/dust/dust.h
+++ b/src/dust/dust.h
@@ -20,13 +20,11 @@
  *   - sputtering:     thermal sputtering, Tsai & Mathews (1995) timescale form
  *   - destruction:    SN shock destruction, McKee (1989) swept-mass form
  *
- * All rate-law constants below are the standard literature forms as commonly
- * cited in the dust-evolution literature (e.g. McKinnon et al. 2016; Li,
- * Narayanan & Dave 2019), NOT copied directly from a specific paper's table.
- * They have not been checked against Li et al. (2019) itself and should be
- * verified against that paper (or with collaborators) before treating any
- * output as science-grade -- see the "Rate-law coefficient caveat" note in
- * the Phase 1 implementation plan.
+ * Rate-law constants below are set to match Li, Narayanan & Dave (2019,
+ * MNRAS, arXiv:1906.09277) directly -- verified against the paper's primary
+ * text and Table 1 (eq. 3, 5-8), not an AI-summarized secondary source. See
+ * the verification note in DUST_PHASE1_IMPLEMENTATION.md for the full
+ * paper-vs-code comparison this was derived from.
  */
 
 /* No #ifdef DUST guard on the content below: this header (and dust_proto.h)
@@ -44,39 +42,45 @@
 
 /* --- SN-channel production --------------------------------------------- */
 /* Fraction of freshly-synthesized SN metal mass that condenses into dust.
- * Placeholder value: SN dust condensation is generally found to be
- * inefficient once reverse-shock processing is accounted for. VERIFY. */
-#define DUST_SN_CONDENSATION_EFFICIENCY 0.01
+ * Li+2019 Table 1: delta_i,dust^SNII = 0.15, uniform across elements (their
+ * eq. 3 is per-element on elemental SNII ejecta mass; Phase 1's single
+ * total-metals scalar applies this efficiency to total SN_MetalsLoss
+ * instead -- a deliberate Phase 1 scope simplification, see "Scope
+ * decisions" in DUST_PHASE1_IMPLEMENTATION.md). */
+#define DUST_SN_CONDENSATION_EFFICIENCY 0.15
 
 /* --- SN shock destruction (McKee 1989) ----------------------------------
- * Rather than an independent literature swept-mass constant, Phase 1 reuses
- * this code's own Kim & Ostriker (2015) shell-mass estimate (Msh -> dm_h in
- * src/stars/star_feedback.c) as the McKee (1989)-style "ISM mass cleared of
- * dust per SN": the dust contained in the swept mass is treated as fully
- * destroyed (sputtered) rather than surviving intact like the metal tracer
- * mass does. See dust_destruction_sn() in dust_destruction_sn.c and its
- * call sites in star_feedback.c for the exact accounting. */
+ * Li+2019 eq. 8: tau_de = M_g / (epsilon * gamma * M_s), epsilon = 0.3
+ * (Table 1). Phase 1 reuses this code's own Kim & Ostriker (2015)
+ * shell-mass estimate (Msh -> dm_h in src/stars/star_feedback.c) in place
+ * of the paper's independent M_s, but does apply the paper's epsilon=0.3
+ * destruction efficiency to it -- see dust_destruction_sn() in
+ * dust_destruction_sn.c and its call sites in star_feedback.c. */
+#define DUST_SN_DESTRUCTION_EFFICIENCY 0.3
 
 /* --- Grain growth (Dwek 1998) -------------------------------------------
- * tau_growth = DUST_GROWTH_TAU_REF_GYR * (n_ref / n_H) * sqrt(T_ref / T)
- * dM/dt|growth = (M_dust / tau_growth) * (1 - M_dust / M_metal)
- * Timescale shortens (rate rises) with increasing T, reflecting faster
- * grain-gas collisions at higher thermal velocity (Hirashita 2000); the
- * reference density is chosen for cold, dense (molecular-cloud-like) gas,
- * so growth is suppressed mainly by the 1/n_H scaling in diffuse gas, not
- * by temperature. VERIFY against Li+2019 -- some implementations instead
- * restrict growth to cold/dense gas by phase cut rather than relying on
- * this T-scaling alone. */
-#define DUST_GROWTH_TAU_REF_GYR 0.03
-#define DUST_GROWTH_REF_NH_CGS 1.0e3   /* cm^-3 */
+ * Li+2019 eq. 5: tau_accr = tau_ref * (rho_ref/rho_g) * (T_ref/T_g) *
+ * (Z_sun/Z_g), values from their text/Table 1: tau_ref=10 Myr,
+ * rho_ref=100 H atoms cm^-3, T_ref=20 K, Z_sun=0.0134 (Asplund et al. 2009).
+ * Both density and temperature ratios are LINEAR (not sqrt), and the
+ * metallicity term is required -- growth speeds up at higher gas-phase
+ * metallicity (more metals available to accrete). */
+#define DUST_GROWTH_TAU_REF_GYR 0.01
+#define DUST_GROWTH_REF_NH_CGS 1.0e2   /* cm^-3 */
 #define DUST_GROWTH_REF_TEMP_K 20.0    /* K */
+#define DUST_SOLAR_METALLICITY_MASSFRAC 0.0134 /* Asplund et al. 2009, as used by Li+2019 */
 
 /* --- Thermal sputtering (Tsai & Mathews 1995) ---------------------------
- * tau_sp = DUST_SPUTTER_TAU_REF_GYR * (n_ref / n_H) * [(T_ref/T)^omega + 1]
- * dM/dt|sputter = -M_dust / tau_sp
- * VERIFY against Li+2019 / Tsai & Mathews (1995) directly. */
+ * Li+2019 eq. 6-7: tau_sp ~ (0.17 Gyr) * (rho_ref/rho_g) *
+ * [(T_0/T_g)^omega + 1], omega=2.5, T_0=2e6 K, rho_ref=1e-27 g cm^-3 (a
+ * TOTAL gas mass density, not a hydrogen number density); then
+ * dM/dt|sputter = -M_dust / (tau_sp / 3). This code passes hydrogen number
+ * density (n_H_cgs, matching dust_get_nH_and_temp() in dust_update.c) into
+ * this rate law, so rho_ref is converted to the equivalent n_H via this
+ * code's own n_H = HYDROGEN_MASSFRAC * rho / PROTONMASS convention:
+ * n_H_ref = 0.76 * 1e-27 g cm^-3 / 1.67262178e-24 g = 4.543e-4 cm^-3. */
 #define DUST_SPUTTER_TAU_REF_GYR 0.17
-#define DUST_SPUTTER_REF_NH_CGS 1.0    /* cm^-3 */
+#define DUST_SPUTTER_REF_NH_CGS 4.543e-4  /* cm^-3, see conversion note above */
 #define DUST_SPUTTER_REF_TEMP_K 2.0e6  /* K */
 #define DUST_SPUTTER_OMEGA 2.5
 

--- a/src/dust/dust.h
+++ b/src/dust/dust.h
@@ -1,0 +1,88 @@
+#ifndef DUST_H
+#define DUST_H
+
+/* Deliberately no #include of ../main/allvars.h here: this header only
+ * defines rate-law constants and is shared by the pure, Arepo-independent
+ * rate-law source files (dust_production_sn.c, dust_destruction_sn.c,
+ * dust_growth.c, dust_sputtering.c) so they can be compiled standalone by
+ * the tests/dust/ unit-test harness (no MPI, no mesh, no SphP/P globals). */
+
+/*
+ * Dust module, Phase 1 (single scalar dust mass per gas cell, see the
+ * dust-module phaseplan doc). Physical processes implemented here:
+ *
+ *   - production:   SN-channel dust condensation only (Phase 1 scope decision:
+ *                    the WINDS channel in this code blends massive-star and
+ *                    AGB-type mass loss into one table with no way to isolate
+ *                    true AGB ejecta, so wind-channel dust production is
+ *                    deferred until that split exists)
+ *   - growth:        Dwek (1998) grain-growth accretion timescale form
+ *   - sputtering:     thermal sputtering, Tsai & Mathews (1995) timescale form
+ *   - destruction:    SN shock destruction, McKee (1989) swept-mass form
+ *
+ * All rate-law constants below are the standard literature forms as commonly
+ * cited in the dust-evolution literature (e.g. McKinnon et al. 2016; Li,
+ * Narayanan & Dave 2019), NOT copied directly from a specific paper's table.
+ * They have not been checked against Li et al. (2019) itself and should be
+ * verified against that paper (or with collaborators) before treating any
+ * output as science-grade -- see the "Rate-law coefficient caveat" note in
+ * the Phase 1 implementation plan.
+ */
+
+/* No #ifdef DUST guard on the content below: this header (and dust_proto.h)
+ * are only ever included from files that are themselves only compiled when
+ * DUST is set -- the source files under src/dust (gated in the Makefile)
+ * and other modules' "#ifdef DUST #include ..." sites. Guarding the
+ * content here too would silently compile the pure rate-law source files
+ * (which don't include allvars.h/arepoconfig.h, by design, for standalone
+ * testability) into empty translation units in the real Arepo build. */
+
+/* Every dust_* function takes an explicit species index so that Phase 2b
+ * (DUST_NUMBER > 1) is a matter of looping this index, not a struct/API
+ * rewrite. Phase 1 only ever calls these with species == 0. */
+#define DUST_PHASE1_SPECIES 0
+
+/* --- SN-channel production --------------------------------------------- */
+/* Fraction of freshly-synthesized SN metal mass that condenses into dust.
+ * Placeholder value: SN dust condensation is generally found to be
+ * inefficient once reverse-shock processing is accounted for. VERIFY. */
+#define DUST_SN_CONDENSATION_EFFICIENCY 0.01
+
+/* --- SN shock destruction (McKee 1989) ----------------------------------
+ * Rather than an independent literature swept-mass constant, Phase 1 reuses
+ * this code's own Kim & Ostriker (2015) shell-mass estimate (Msh -> dm_h in
+ * src/stars/star_feedback.c) as the McKee (1989)-style "ISM mass cleared of
+ * dust per SN": the dust contained in the swept mass is treated as fully
+ * destroyed (sputtered) rather than surviving intact like the metal tracer
+ * mass does. See dust_destruction_sn() in dust_destruction_sn.c and its
+ * call sites in star_feedback.c for the exact accounting. */
+
+/* --- Grain growth (Dwek 1998) -------------------------------------------
+ * tau_growth = DUST_GROWTH_TAU_REF_GYR * (n_ref / n_H) * sqrt(T_ref / T)
+ * dM/dt|growth = (M_dust / tau_growth) * (1 - M_dust / M_metal)
+ * Timescale shortens (rate rises) with increasing T, reflecting faster
+ * grain-gas collisions at higher thermal velocity (Hirashita 2000); the
+ * reference density is chosen for cold, dense (molecular-cloud-like) gas,
+ * so growth is suppressed mainly by the 1/n_H scaling in diffuse gas, not
+ * by temperature. VERIFY against Li+2019 -- some implementations instead
+ * restrict growth to cold/dense gas by phase cut rather than relying on
+ * this T-scaling alone. */
+#define DUST_GROWTH_TAU_REF_GYR 0.03
+#define DUST_GROWTH_REF_NH_CGS 1.0e3   /* cm^-3 */
+#define DUST_GROWTH_REF_TEMP_K 20.0    /* K */
+
+/* --- Thermal sputtering (Tsai & Mathews 1995) ---------------------------
+ * tau_sp = DUST_SPUTTER_TAU_REF_GYR * (n_ref / n_H) * [(T_ref/T)^omega + 1]
+ * dM/dt|sputter = -M_dust / tau_sp
+ * VERIFY against Li+2019 / Tsai & Mathews (1995) directly. */
+#define DUST_SPUTTER_TAU_REF_GYR 0.17
+#define DUST_SPUTTER_REF_NH_CGS 1.0    /* cm^-3 */
+#define DUST_SPUTTER_REF_TEMP_K 2.0e6  /* K */
+#define DUST_SPUTTER_OMEGA 2.5
+
+/* Rate-ODE bisection tolerance / iteration cap, mirroring DoCooling() in
+ * src/cooling/cooling.c */
+#define DUST_ODE_TOLERANCE 1.0e-6
+#define DUST_ODE_MAXITER 300
+
+#endif /* DUST_H */

--- a/src/dust/dust_destruction_sn.c
+++ b/src/dust/dust_destruction_sn.c
@@ -4,12 +4,13 @@
 /*! \brief Dust mass destroyed in a gas cell by a single SN shock.
  *
  *  McKee (1989)-style swept-mass form: the destroyed fraction of a cell's
- *  dust is destroy_mass_threshold (the ISM mass processed by this SN's
- *  shock -- see the call sites in src/stars/star_feedback.c, which pass in
- *  this code's own Kim & Ostriker 2015 swept-mass estimate) as a fraction
- *  of the cell's gas mass, weighted by the same per-face/per-cell weight
- *  the SN event's metal deposit uses, capped at destroying all of the
- *  cell's dust.
+ *  dust is DUST_SN_DESTRUCTION_EFFICIENCY (epsilon=0.3, Li+2019 eq. 8/
+ *  Table 1) times destroy_mass_threshold (the ISM mass processed by this
+ *  SN's shock -- see the call sites in src/stars/star_feedback.c, which
+ *  pass in this code's own Kim & Ostriker 2015 swept-mass estimate in place
+ *  of the paper's independent M_s) as a fraction of the cell's gas mass,
+ *  weighted by the same per-face/per-cell weight the SN event's metal
+ *  deposit uses, capped at destroying all of the cell's dust.
  *
  *  Pure function -- M_dust, cell_gas_mass and destroy_mass_threshold must
  *  all be passed in the same consistent mass unit.
@@ -30,7 +31,7 @@ double dust_destruction_sn(int species, double M_dust, double cell_gas_mass, dou
   if(M_dust <= 0 || cell_gas_mass <= 0 || weight <= 0)
     return 0.0;
 
-  double destroyed_fraction = weight * destroy_mass_threshold / cell_gas_mass;
+  double destroyed_fraction = DUST_SN_DESTRUCTION_EFFICIENCY * weight * destroy_mass_threshold / cell_gas_mass;
 
   if(destroyed_fraction > 1.0)
     destroyed_fraction = 1.0;

--- a/src/dust/dust_destruction_sn.c
+++ b/src/dust/dust_destruction_sn.c
@@ -1,0 +1,39 @@
+#include "dust.h"
+#include "dust_proto.h"
+
+/*! \brief Dust mass destroyed in a gas cell by a single SN shock.
+ *
+ *  McKee (1989)-style swept-mass form: the destroyed fraction of a cell's
+ *  dust is destroy_mass_threshold (the ISM mass processed by this SN's
+ *  shock -- see the call sites in src/stars/star_feedback.c, which pass in
+ *  this code's own Kim & Ostriker 2015 swept-mass estimate) as a fraction
+ *  of the cell's gas mass, weighted by the same per-face/per-cell weight
+ *  the SN event's metal deposit uses, capped at destroying all of the
+ *  cell's dust.
+ *
+ *  Pure function -- M_dust, cell_gas_mass and destroy_mass_threshold must
+ *  all be passed in the same consistent mass unit.
+ *
+ *  \param[in] species              dust species index (Phase 1: always DUST_PHASE1_SPECIES)
+ *  \param[in] M_dust               current dust mass in the cell
+ *  \param[in] cell_gas_mass        current gas mass of the cell
+ *  \param[in] destroy_mass_threshold ISM mass processed by this SN's shock, in the caller's mass unit
+ *  \param[in] weight               this SN event's fractional deposit onto this cell, in [0,1]
+ *
+ *  \return dust mass destroyed (>= 0, <= M_dust)
+ */
+double dust_destruction_sn(int species, double M_dust, double cell_gas_mass, double destroy_mass_threshold,
+                            double weight)
+{
+  (void)species; /* Phase 1: single species; kept for the Phase 2b API */
+
+  if(M_dust <= 0 || cell_gas_mass <= 0 || weight <= 0)
+    return 0.0;
+
+  double destroyed_fraction = weight * destroy_mass_threshold / cell_gas_mass;
+
+  if(destroyed_fraction > 1.0)
+    destroyed_fraction = 1.0;
+
+  return destroyed_fraction * M_dust;
+}

--- a/src/dust/dust_growth.c
+++ b/src/dust/dust_growth.c
@@ -5,7 +5,8 @@
 
 /*! \brief Grain growth (accretion) rate, Dwek (1998) timescale form.
  *
- *  tau_growth = DUST_GROWTH_TAU_REF_GYR * (n_ref / n_H) * sqrt(T_ref / T)
+ *  tau_growth = DUST_GROWTH_TAU_REF_GYR * (n_ref / n_H) * (T_ref / T) *
+ *               (Z_sun / Z_gas)
  *  dM/dt = (M_dust / tau_growth) * (1 - M_dust / M_metal)
  *
  *  The (1 - M_dust/M_metal) factor saturates growth as the dust mass
@@ -15,21 +16,24 @@
  *
  *  Pure function -- M_dust and M_metal must share a consistent mass unit;
  *  the return value is in that same unit, per Gyr. n_H_cgs/temp_K must be
- *  physical (proper) values in cm^-3 / K.
+ *  physical (proper) values in cm^-3 / K. Z_gas_massfrac is the cell's
+ *  gas-phase metal mass fraction (dimensionless).
  *
- *  \param[in] species  dust species index (Phase 1: always DUST_PHASE1_SPECIES)
- *  \param[in] M_dust   current dust mass in the cell
- *  \param[in] M_metal  current total (gas-phase + dust-phase) metal mass in the cell
- *  \param[in] n_H_cgs  hydrogen number density, cm^-3
- *  \param[in] temp_K   gas temperature, K
+ *  \param[in] species         dust species index (Phase 1: always DUST_PHASE1_SPECIES)
+ *  \param[in] M_dust          current dust mass in the cell
+ *  \param[in] M_metal         current total (gas-phase + dust-phase) metal mass in the cell
+ *  \param[in] n_H_cgs         hydrogen number density, cm^-3
+ *  \param[in] temp_K          gas temperature, K
+ *  \param[in] Z_gas_massfrac  gas-phase metal mass fraction, dimensionless
  *
  *  \return dM/dt due to growth, in [mass unit of M_dust] / Gyr
  */
-double dust_growth_rate(int species, double M_dust, double M_metal, double n_H_cgs, double temp_K)
+double dust_growth_rate(int species, double M_dust, double M_metal, double n_H_cgs, double temp_K,
+                         double Z_gas_massfrac)
 {
   (void)species; /* Phase 1: single species; kept for the Phase 2b API */
 
-  if(M_dust <= 0 || M_metal <= 0 || n_H_cgs <= 0 || temp_K <= 0)
+  if(M_dust <= 0 || M_metal <= 0 || n_H_cgs <= 0 || temp_K <= 0 || Z_gas_massfrac <= 0)
     return 0.0;
 
   double remaining_fraction = 1.0 - M_dust / M_metal;
@@ -37,7 +41,8 @@ double dust_growth_rate(int species, double M_dust, double M_metal, double n_H_c
     return 0.0;
 
   double tau_growth_gyr = DUST_GROWTH_TAU_REF_GYR * (DUST_GROWTH_REF_NH_CGS / n_H_cgs) *
-                           sqrt(DUST_GROWTH_REF_TEMP_K / temp_K);
+                           (DUST_GROWTH_REF_TEMP_K / temp_K) *
+                           (DUST_SOLAR_METALLICITY_MASSFRAC / Z_gas_massfrac);
 
   return (M_dust / tau_growth_gyr) * remaining_fraction;
 }

--- a/src/dust/dust_growth.c
+++ b/src/dust/dust_growth.c
@@ -1,0 +1,43 @@
+#include <math.h>
+
+#include "dust.h"
+#include "dust_proto.h"
+
+/*! \brief Grain growth (accretion) rate, Dwek (1998) timescale form.
+ *
+ *  tau_growth = DUST_GROWTH_TAU_REF_GYR * (n_ref / n_H) * sqrt(T_ref / T)
+ *  dM/dt = (M_dust / tau_growth) * (1 - M_dust / M_metal)
+ *
+ *  The (1 - M_dust/M_metal) factor saturates growth as the dust mass
+ *  approaches the cell's total metal budget, so callers do not need a
+ *  separate clamp against M_metal for this term alone (dust_cell() still
+ *  clamps the combined update against GasMetals as a safety net).
+ *
+ *  Pure function -- M_dust and M_metal must share a consistent mass unit;
+ *  the return value is in that same unit, per Gyr. n_H_cgs/temp_K must be
+ *  physical (proper) values in cm^-3 / K.
+ *
+ *  \param[in] species  dust species index (Phase 1: always DUST_PHASE1_SPECIES)
+ *  \param[in] M_dust   current dust mass in the cell
+ *  \param[in] M_metal  current total (gas-phase + dust-phase) metal mass in the cell
+ *  \param[in] n_H_cgs  hydrogen number density, cm^-3
+ *  \param[in] temp_K   gas temperature, K
+ *
+ *  \return dM/dt due to growth, in [mass unit of M_dust] / Gyr
+ */
+double dust_growth_rate(int species, double M_dust, double M_metal, double n_H_cgs, double temp_K)
+{
+  (void)species; /* Phase 1: single species; kept for the Phase 2b API */
+
+  if(M_dust <= 0 || M_metal <= 0 || n_H_cgs <= 0 || temp_K <= 0)
+    return 0.0;
+
+  double remaining_fraction = 1.0 - M_dust / M_metal;
+  if(remaining_fraction <= 0)
+    return 0.0;
+
+  double tau_growth_gyr = DUST_GROWTH_TAU_REF_GYR * (DUST_GROWTH_REF_NH_CGS / n_H_cgs) *
+                           sqrt(DUST_GROWTH_REF_TEMP_K / temp_K);
+
+  return (M_dust / tau_growth_gyr) * remaining_fraction;
+}

--- a/src/dust/dust_io.c
+++ b/src/dust/dust_io.c
@@ -1,0 +1,31 @@
+#include <mpi.h>
+
+#include "../main/allvars.h"
+#include "../main/proto.h"
+#include "dust.h"
+#include "dust_proto.h"
+
+#ifdef DUST
+
+/*! \brief Register dust snapshot fields.
+ *
+ *  Called from init_io_fields() in src/io/io_fields.c under #ifdef DUST.
+ *  No module currently has its own dedicated io file (all fields funnel
+ *  through the shared io_fields.c) -- this is a deliberate small deviation
+ *  from that convention, kept to a single hook call in the shared file so
+ *  it stays low-risk.
+ *
+ *  Phase 1 keeps the snapshot footprint minimal: just the dust mass itself.
+ *  D/Z and the gas-phase/dust-phase metal-budget split are left to
+ *  post-processing (they're trivially derived from GasDustMass and the
+ *  existing PassiveScalars metallicity output).
+ */
+void dust_init_io_fields(void)
+{
+  init_field(IO_DUST_MASS, "DUST", "DustMass", MEM_MY_FLOAT, FILE_MY_IO_FLOAT, FILE_NONE, 1, A_SPHP, &SphP[0].GasDustMass, 0,
+             GAS_ONLY);
+  init_units(IO_DUST_MASS, 0., -1., 0., 1., 0., All.UnitMass_in_g);
+  init_snapshot_type(IO_DUST_MASS, SN_MINI);
+}
+
+#endif /* DUST */

--- a/src/dust/dust_production_sn.c
+++ b/src/dust/dust_production_sn.c
@@ -1,0 +1,22 @@
+#include "dust.h"
+#include "dust_proto.h"
+
+/*! \brief Dust mass condensed from a single SN event's ejected metal mass.
+ *
+ *  Phase 1: SN-channel only (see dust.h). Pure function -- SN_MetalsLoss and
+ *  the return value share whatever consistent mass unit the caller uses.
+ *
+ *  \param[in] species     dust species index (Phase 1: always DUST_PHASE1_SPECIES)
+ *  \param[in] SN_MetalsLoss metal mass ejected by this SN event
+ *
+ *  \return dust mass condensed from this event
+ */
+double dust_production_sn(int species, double SN_MetalsLoss)
+{
+  (void)species; /* Phase 1: single species; kept for the Phase 2b API */
+
+  if(SN_MetalsLoss <= 0)
+    return 0.0;
+
+  return DUST_SN_CONDENSATION_EFFICIENCY * SN_MetalsLoss;
+}

--- a/src/dust/dust_proto.h
+++ b/src/dust/dust_proto.h
@@ -15,7 +15,8 @@ double dust_destruction_sn(int species, double M_dust, double cell_gas_mass, dou
 /* Continuous rate terms (per active gas cell), used by dust_cell(). Return
  * dM/dt in [mass-unit of M_dust / Gyr]; density/temperature must be passed
  * in physical cgs units (n_H in cm^-3, T in K). */
-double dust_growth_rate(int species, double M_dust, double M_metal, double n_H_cgs, double temp_K);
+double dust_growth_rate(int species, double M_dust, double M_metal, double n_H_cgs, double temp_K,
+                         double Z_gas_massfrac);
 double dust_sputtering_rate(int species, double M_dust, double n_H_cgs, double temp_K);
 
 /* Per-cell rate-ODE integration and driver, mirrors cool_cell()/cooling_only()

--- a/src/dust/dust_proto.h
+++ b/src/dust/dust_proto.h
@@ -1,0 +1,30 @@
+#ifndef DUST_PROTO_H
+#define DUST_PROTO_H
+
+/* No #ifdef DUST guard here -- see the note at the top of dust.h. */
+
+/* SN-channel production/destruction (event-driven, called from
+ * src/stars/star_feedback.c per SN event). Pure functions: all masses must
+ * be passed in the same (arbitrary but consistent) unit system -- unit
+ * conversion is the caller's responsibility, so these stay testable
+ * standalone. */
+double dust_production_sn(int species, double SN_MetalsLoss);
+double dust_destruction_sn(int species, double M_dust, double cell_gas_mass, double destroy_mass_threshold,
+                            double weight);
+
+/* Continuous rate terms (per active gas cell), used by dust_cell(). Return
+ * dM/dt in [mass-unit of M_dust / Gyr]; density/temperature must be passed
+ * in physical cgs units (n_H in cm^-3, T in K). */
+double dust_growth_rate(int species, double M_dust, double M_metal, double n_H_cgs, double temp_K);
+double dust_sputtering_rate(int species, double M_dust, double n_H_cgs, double temp_K);
+
+/* Per-cell rate-ODE integration and driver, mirrors cool_cell()/cooling_only()
+ * in src/cooling/cooling.c */
+void dust_cell(int i);
+void dust_processes(void);
+
+/* Snapshot I/O registration, called from init_io_fields() in
+ * src/io/io_fields.c */
+void dust_init_io_fields(void);
+
+#endif /* DUST_PROTO_H */

--- a/src/dust/dust_sputtering.c
+++ b/src/dust/dust_sputtering.c
@@ -6,7 +6,7 @@
 /*! \brief Thermal sputtering rate, Tsai & Mathews (1995) timescale form.
  *
  *  tau_sp = DUST_SPUTTER_TAU_REF_GYR * (n_ref / n_H) * [(T_ref/T)^omega + 1]
- *  dM/dt = -M_dust / tau_sp
+ *  dM/dt = -M_dust / (tau_sp / 3)
  *
  *  Pure function -- M_dust and the return value share a consistent mass
  *  unit, per Gyr. n_H_cgs/temp_K must be physical (proper) values in
@@ -29,5 +29,5 @@ double dust_sputtering_rate(int species, double M_dust, double n_H_cgs, double t
   double tau_sp_gyr = DUST_SPUTTER_TAU_REF_GYR * (DUST_SPUTTER_REF_NH_CGS / n_H_cgs) *
                        (pow(DUST_SPUTTER_REF_TEMP_K / temp_K, DUST_SPUTTER_OMEGA) + 1.0);
 
-  return -M_dust / tau_sp_gyr;
+  return -3.0 * M_dust / tau_sp_gyr;
 }

--- a/src/dust/dust_sputtering.c
+++ b/src/dust/dust_sputtering.c
@@ -1,0 +1,33 @@
+#include <math.h>
+
+#include "dust.h"
+#include "dust_proto.h"
+
+/*! \brief Thermal sputtering rate, Tsai & Mathews (1995) timescale form.
+ *
+ *  tau_sp = DUST_SPUTTER_TAU_REF_GYR * (n_ref / n_H) * [(T_ref/T)^omega + 1]
+ *  dM/dt = -M_dust / tau_sp
+ *
+ *  Pure function -- M_dust and the return value share a consistent mass
+ *  unit, per Gyr. n_H_cgs/temp_K must be physical (proper) values in
+ *  cm^-3 / K.
+ *
+ *  \param[in] species  dust species index (Phase 1: always DUST_PHASE1_SPECIES)
+ *  \param[in] M_dust   current dust mass in the cell
+ *  \param[in] n_H_cgs  hydrogen number density, cm^-3
+ *  \param[in] temp_K   gas temperature, K
+ *
+ *  \return dM/dt due to sputtering (<= 0), in [mass unit of M_dust] / Gyr
+ */
+double dust_sputtering_rate(int species, double M_dust, double n_H_cgs, double temp_K)
+{
+  (void)species; /* Phase 1: single species; kept for the Phase 2b API */
+
+  if(M_dust <= 0 || n_H_cgs <= 0 || temp_K <= 0)
+    return 0.0;
+
+  double tau_sp_gyr = DUST_SPUTTER_TAU_REF_GYR * (DUST_SPUTTER_REF_NH_CGS / n_H_cgs) *
+                       (pow(DUST_SPUTTER_REF_TEMP_K / temp_K, DUST_SPUTTER_OMEGA) + 1.0);
+
+  return -M_dust / tau_sp_gyr;
+}

--- a/src/dust/dust_update.c
+++ b/src/dust/dust_update.c
@@ -1,0 +1,155 @@
+#include <math.h>
+#include <mpi.h>
+#include <stdlib.h>
+
+#include "../main/allvars.h"
+#include "../main/proto.h"
+#include "dust.h"
+#include "dust_proto.h"
+
+#ifdef DUST
+
+/*! \brief Physical hydrogen number density and gas temperature for a cell.
+ *
+ *  Mirrors the unit handling in DoCooling()/cool_cell() (src/cooling/cooling.c)
+ *  so the dust rate laws see the same physical density/temperature cooling
+ *  itself uses.
+ */
+static void dust_get_nH_and_temp(int i, double *n_H_cgs, double *temp_K)
+{
+  double dens_code = SphP[i].Density * All.cf_a3inv;
+  double dens_cgs   = dens_code * All.UnitDensity_in_cgs * All.HubbleParam * All.HubbleParam;
+
+  *n_H_cgs = HYDROGEN_MASSFRAC * dens_cgs / PROTONMASS;
+
+#ifdef USE_GRACKLE
+  *temp_K = CallGrackle(SphP[i].Utherm, dens_code, 0.0, i, 2);
+#else
+  double ne    = SphP[i].Ne;
+  double u_cgs = SphP[i].Utherm * All.UnitPressure_in_cgs / All.UnitDensity_in_cgs;
+  *temp_K      = convert_u_to_temp(u_cgs, dens_cgs, &ne);
+#endif
+}
+
+/*! \brief Residual for the implicit backward-Euler dust growth/sputtering
+ *  update: M - M_old - dt * (growth_rate(M) + sputtering_rate(M)).
+ */
+static double dust_ode_residual(double M, double M_old, double M_metal, double n_H_cgs, double temp_K, double dt_gyr)
+{
+  double rate = dust_growth_rate(DUST_PHASE1_SPECIES, M, M_metal, n_H_cgs, temp_K) +
+                dust_sputtering_rate(DUST_PHASE1_SPECIES, M, n_H_cgs, temp_K);
+
+  return M - M_old - dt_gyr * rate;
+}
+
+/*! \brief Apply the combined growth + thermal sputtering rate-ODE to a
+ *  single gas cell's dust mass, over its own hydro timestep.
+ *
+ *  Solved via bisection, bracketed by the cell's physical dust-mass bounds
+ *  [0, GasMetals] (dust can never exceed the metal budget it condensed
+ *  from) -- the same bracket+bisect spirit as DoCooling() in
+ *  src/cooling/cooling.c, but bounded by physics rather than an expanding
+ *  search, since M_dust (unlike internal energy) has known finite bounds.
+ *
+ *  \param[in] i index of the gas cell
+ */
+void dust_cell(int i)
+{
+  double dt, dtime, dt_gyr;
+
+  dt    = (P[i].TimeBinHydro ? (((integertime)1) << P[i].TimeBinHydro) : 0) * All.Timebase_interval;
+  dtime = All.cf_atime * dt / All.cf_time_hubble_a;
+
+  if(dtime <= 0)
+    return;
+
+  dt_gyr = (dtime * All.UnitTime_in_s / All.HubbleParam) / SEC_PER_GIGAYEAR;
+
+  double M_old   = SphP[i].GasDustMass;
+  double M_metal = SphP[i].GasMetals;
+
+  if(M_metal <= 0)
+    {
+      SphP[i].GasDustMass = 0;
+      sync_primitive_from_conserved(i, DUST_INDEX);
+      return;
+    }
+
+  double n_H_cgs, temp_K;
+  dust_get_nH_and_temp(i, &n_H_cgs, &temp_K);
+
+  double lo = 0.0, hi = M_metal;
+  double f_lo = dust_ode_residual(lo, M_old, M_metal, n_H_cgs, temp_K, dt_gyr);
+  double f_hi = dust_ode_residual(hi, M_old, M_metal, n_H_cgs, temp_K, dt_gyr);
+
+  double M_new;
+
+  if(f_lo >= 0)
+    {
+      M_new = lo; /* even M=0 overshoots: sputtering removes all dust this step */
+    }
+  else if(f_hi <= 0)
+    {
+      M_new = hi; /* even M=M_metal undershoots: growth saturates at the metal budget */
+    }
+  else
+    {
+      int iter = 0;
+      double dM;
+
+      do
+        {
+          M_new     = 0.5 * (lo + hi);
+          double f  = dust_ode_residual(M_new, M_old, M_metal, n_H_cgs, temp_K, dt_gyr);
+
+          if(f > 0)
+            hi = M_new;
+          else
+            lo = M_new;
+
+          dM = hi - lo;
+          iter++;
+        }
+      while(dM > DUST_ODE_TOLERANCE * fmax(hi, 1e-300) && iter < DUST_ODE_MAXITER);
+
+      M_new = 0.5 * (lo + hi);
+    }
+
+  if(M_new < 0)
+    M_new = 0;
+  if(M_new > M_metal)
+    M_new = M_metal;
+
+  SphP[i].GasDustMass = M_new;
+  sync_primitive_from_conserved(i, DUST_INDEX);
+}
+
+/*! \brief Apply dust growth/sputtering to all active gas cells.
+ *
+ *  Mirrors cooling_only() in src/cooling/cooling.c, and is called
+ *  immediately after the COOLING block in
+ *  calculate_non_standard_physics_end_of_step() (src/main/run.c) so the
+ *  rate laws see post-cooling temperature.
+ */
+void dust_processes(void)
+{
+  int idx, i;
+
+  CPU_Step[CPU_MISC] += measure_time();
+
+  for(idx = 0; idx < TimeBinsHydro.NActiveParticles; idx++)
+    {
+      i = TimeBinsHydro.ActiveParticleList[idx];
+      if(i >= 0)
+        {
+          if(P[i].Mass == 0 && P[i].ID == 0)
+            continue; /* skip cells that have been swallowed or eliminated */
+
+          dust_cell(i);
+        }
+    }
+
+  CPU_Step[CPU_COOLINGSFR] += measure_time();
+}
+
+#endif /* DUST */

--- a/src/dust/dust_update.c
+++ b/src/dust/dust_update.c
@@ -34,9 +34,10 @@ static void dust_get_nH_and_temp(int i, double *n_H_cgs, double *temp_K)
 /*! \brief Residual for the implicit backward-Euler dust growth/sputtering
  *  update: M - M_old - dt * (growth_rate(M) + sputtering_rate(M)).
  */
-static double dust_ode_residual(double M, double M_old, double M_metal, double n_H_cgs, double temp_K, double dt_gyr)
+static double dust_ode_residual(double M, double M_old, double M_metal, double n_H_cgs, double temp_K,
+                                 double Z_gas_massfrac, double dt_gyr)
 {
-  double rate = dust_growth_rate(DUST_PHASE1_SPECIES, M, M_metal, n_H_cgs, temp_K) +
+  double rate = dust_growth_rate(DUST_PHASE1_SPECIES, M, M_metal, n_H_cgs, temp_K, Z_gas_massfrac) +
                 dust_sputtering_rate(DUST_PHASE1_SPECIES, M, n_H_cgs, temp_K);
 
   return M - M_old - dt_gyr * rate;
@@ -78,9 +79,11 @@ void dust_cell(int i)
   double n_H_cgs, temp_K;
   dust_get_nH_and_temp(i, &n_H_cgs, &temp_K);
 
+  double Z_gas_massfrac = SphP[i].GasMetallicity;
+
   double lo = 0.0, hi = M_metal;
-  double f_lo = dust_ode_residual(lo, M_old, M_metal, n_H_cgs, temp_K, dt_gyr);
-  double f_hi = dust_ode_residual(hi, M_old, M_metal, n_H_cgs, temp_K, dt_gyr);
+  double f_lo = dust_ode_residual(lo, M_old, M_metal, n_H_cgs, temp_K, Z_gas_massfrac, dt_gyr);
+  double f_hi = dust_ode_residual(hi, M_old, M_metal, n_H_cgs, temp_K, Z_gas_massfrac, dt_gyr);
 
   double M_new;
 
@@ -100,7 +103,7 @@ void dust_cell(int i)
       do
         {
           M_new     = 0.5 * (lo + hi);
-          double f  = dust_ode_residual(M_new, M_old, M_metal, n_H_cgs, temp_K, dt_gyr);
+          double f  = dust_ode_residual(M_new, M_old, M_metal, n_H_cgs, temp_K, Z_gas_massfrac, dt_gyr);
 
           if(f > 0)
             hi = M_new;

--- a/src/io/io_fields.c
+++ b/src/io/io_fields.c
@@ -896,4 +896,8 @@ void init_io_fields()
   init_units(IO_BH_DONOR_VELOCITY, 0.5, 0., 0., 0., 1., All.UnitVelocity_in_cm_per_s);
   init_snapshot_type(IO_BH_DONOR_VELOCITY, SN_MINI);
 #endif /* #if defined(HALO_SEEDING) && defined(BLACKHOLES) */
+
+#ifdef DUST
+  dust_init_io_fields();
+#endif
 }

--- a/src/io/io_fields.c
+++ b/src/io/io_fields.c
@@ -749,6 +749,17 @@ void init_io_fields()
   init_units(IO_PASS, 0., 0., 0., 0., 0., 0.0);
 #endif /* #ifdef PASSIVE_SCALARS */
 
+#ifdef METALS
+  /* Dedicated, named alias into the METALS_INDEX slot of PassiveScalars
+   * above -- redundant with it (same pattern IO_DUST_MASS already uses for
+   * DUST_INDEX), so post-processing doesn't need to know the PassiveScalars
+   * array's internal offset ordering to get gas-phase metallicity. Mirrors
+   * IO_STAR_METALS, which stars have always had a dedicated field for. */
+  init_field(IO_GAS_METALS, "GZ  ", "Metallicity", MEM_MY_FLOAT, FILE_MY_IO_FLOAT, FILE_NONE, 1, A_SPHP, &SphP[0].GasMetallicity, 0,
+             GAS_ONLY);
+  init_units(IO_GAS_METALS, 0., 0., 0., 0., 0., 0.);
+#endif
+
   /* OTHER */
 
 #ifdef SAVE_HSML_IN_SNAPSHOT

--- a/src/main/allvars.h
+++ b/src/main/allvars.h
@@ -2191,6 +2191,9 @@ enum iofields
   IO_CURLVEL,
   IO_COOLHEAT,
   IO_PASS,
+#ifdef METALS
+  IO_GAS_METALS,
+#endif
 
   IO_SUBFINDHSML,
   IO_SUBFINDDENSITY,

--- a/src/main/allvars.h
+++ b/src/main/allvars.h
@@ -345,6 +345,8 @@ extern hwloc_cpuset_t cpuset_thread[NUM_THREADS];
 #define GRACKLE_SPECIES_NUMBER 0
 #define JET_INDEX 0
 #define JET_NUMBER 0
+#define DUST_INDEX 0
+#define DUST_NUMBER 0
 
 /* Metallicity */
 #ifdef METALS
@@ -378,8 +380,16 @@ extern hwloc_cpuset_t cpuset_thread[NUM_THREADS];
 #undef JET_INDEX
 #undef JET_NUMBER
 #define JET_INDEX (METALS_INDEX + METALS_NUMBER + GRACKLE_SPECIES_NUMBER)
-#define JET_NUMBER 1 
-#endif 
+#define JET_NUMBER 1
+#endif
+
+/* Dust mass (Phase 1: single species; DUST_NUMBER is the Phase 2b extension point) */
+#ifdef DUST
+#undef DUST_INDEX
+#undef DUST_NUMBER
+#define DUST_INDEX (METALS_INDEX + METALS_NUMBER + GRACKLE_SPECIES_NUMBER + JET_NUMBER)
+#define DUST_NUMBER 1
+#endif
 
 /* Potential extension */
 #ifndef PASSIVE_SCALARS_EXTRA
@@ -387,7 +397,7 @@ extern hwloc_cpuset_t cpuset_thread[NUM_THREADS];
 #endif
 
 /* Total passive scalar count */
-#define PASSIVE_SCALARS (METALS_NUMBER + GRACKLE_SPECIES_NUMBER + JET_NUMBER + PASSIVE_SCALARS_EXTRA)
+#define PASSIVE_SCALARS (METALS_NUMBER + GRACKLE_SPECIES_NUMBER + JET_NUMBER + DUST_NUMBER + PASSIVE_SCALARS_EXTRA)
 
 /* Refinement Default */
 #define SCALAR_REFINE 0
@@ -1814,7 +1824,13 @@ extern struct sph_particle_data
 /* Jet tracer */
 #ifdef JET_TRACER
 #define JetTracer PScalars[JET_INDEX]
-#define JetTracerConserved PConservedScalars[JET_INDEX]    
+#define JetTracerConserved PConservedScalars[JET_INDEX]
+#endif
+
+/* Dust mass */
+#ifdef DUST
+#define GasDustMassFraction PScalars[DUST_INDEX]
+#define GasDustMass PConservedScalars[DUST_INDEX]
 #endif
 
 /* Cooling */
@@ -1852,6 +1868,9 @@ extern struct sph_particle_data
 #endif
 #ifdef METALS
   MyDouble StarMetalsFeed;
+#endif
+#ifdef DUST
+  MyDouble StarDustFeed; /* signed: SN dust production minus SN shock destruction, staged for this cell */
 #endif
   MyDouble StarMomentumFeed[3];
   MyDouble StarEnergyFeed;
@@ -2223,6 +2242,9 @@ enum iofields
   IO_BH_FORMATION_METALLICITY,
   IO_BH_FORMATION_CHANNEL,
   IO_BH_DONOR_VELOCITY,
+#endif
+#ifdef DUST
+  IO_DUST_MASS,
 #endif
   IO_LASTENTRY /* This should be kept - it signals the end of the list */
 };

--- a/src/main/proto.h
+++ b/src/main/proto.h
@@ -60,7 +60,11 @@
 
 #if defined(STARS)
 #include "../stars/star_proto.h"
-#endif 
+#endif
+
+#if defined(DUST)
+#include "../dust/dust_proto.h"
+#endif
 
 #ifdef JEANS_SF
 double get_jeans_length(int i);

--- a/src/main/run.c
+++ b/src/main/run.c
@@ -529,6 +529,10 @@ void calculate_non_standard_physics_end_of_step(void)
 #endif /* #ifdef USE_SFR #else */
 #endif /* #ifdef COOLING */
 
+#ifdef DUST
+      dust_processes();
+#endif
+
 #ifdef STAR_FEEDBACK_ACTIVE
       star_exit();
 #endif

--- a/src/mesh/mesh.h
+++ b/src/mesh/mesh.h
@@ -141,11 +141,17 @@ extern struct primexch
 #ifdef METALS
   MyDouble Metals;
 #endif
+#ifdef DUST
+  MyDouble Dust;
+#endif
   MyDouble Momentum[3];
 
   MyDouble MassFeed;
 #ifdef METALS
   MyDouble MetalsFeed;
+#endif
+#ifdef DUST
+  MyDouble DustFeed;
 #endif
   MyDouble MomentumFeed[3];
 #endif

--- a/src/mesh/voronoi/voronoi_exchange.c
+++ b/src/mesh/voronoi/voronoi_exchange.c
@@ -284,12 +284,18 @@ void exchange_primitive_variables(void)
 #ifdef METALS
               tmpPrimExch[off].Metals = SphP[place].GasMetals;
 #endif
+#ifdef DUST
+              tmpPrimExch[off].Dust = SphP[place].GasDustMass;
+#endif
               for(int k = 0; k < 3; k++)
                 tmpPrimExch[off].Momentum[k] = SphP[place].Momentum[k];
 
               tmpPrimExch[off].MassFeed = SphP[place].StarMassFeed;
 #ifdef METALS
               tmpPrimExch[off].MetalsFeed = SphP[place].StarMetalsFeed;
+#endif
+#ifdef DUST
+              tmpPrimExch[off].DustFeed = SphP[place].StarDustFeed;
 #endif
               for(int k = 0; k < 3; k++)
                 tmpPrimExch[off].MomentumFeed[k] = SphP[place].StarMomentumFeed[k];
@@ -409,12 +415,18 @@ void exchange_primitive_variables_and_gradients(void)
 #ifdef METALS
               tmpPrimExch[off].Metals = SphP[place].GasMetals;
 #endif
+#ifdef DUST
+              tmpPrimExch[off].Dust = SphP[place].GasDustMass;
+#endif
               for(int k = 0; k < 3; k++)
                 tmpPrimExch[off].Momentum[k] = SphP[place].Momentum[k];
 
               tmpPrimExch[off].MassFeed = SphP[place].StarMassFeed;
 #ifdef METALS
               tmpPrimExch[off].MetalsFeed = SphP[place].StarMetalsFeed;
+#endif
+#ifdef DUST
+              tmpPrimExch[off].DustFeed = SphP[place].StarDustFeed;
 #endif
               for(int k = 0; k < 3; k++)
                 tmpPrimExch[off].MomentumFeed[k] = SphP[place].StarMomentumFeed[k];

--- a/src/stars/star_feedback.c
+++ b/src/stars/star_feedback.c
@@ -6,6 +6,9 @@
 
 #include "../main/allvars.h"
 #include "../main/proto.h"
+#ifdef DUST
+#include "../dust/dust.h"
+#endif
 
 #if defined(WINDS) || defined(SUPERNOVAE)
 
@@ -41,6 +44,9 @@ struct Feedback_Kick
 #endif
 #ifdef METALS
   MyDouble SN_DeltaMetals;
+#endif
+#ifdef DUST
+  MyDouble SN_DeltaDust; /* signed: production minus shock destruction */
 #endif
   MyDouble SN_DeltaP[3];
   MyDouble SN_DeltaE;
@@ -79,6 +85,9 @@ static void apply_kick(int j, const struct Feedback_Kick *Kick)
   SphP[j].StarMetalsFeed += Kick->SN_DeltaMetals;
   All.StarFeedbackLocal[1] += Kick->SN_DeltaMetals;
 #endif
+#ifdef DUST
+  SphP[j].StarDustFeed += Kick->SN_DeltaDust;
+#endif
   for(int k = 0; k < 3; k++)
     SphP[j].StarMomentumFeed[k] += Kick->SN_DeltaP[k];
 
@@ -103,6 +112,9 @@ static void apply_kick_primexch(int particle, const struct Feedback_Kick *Kick)
   PrimExch[particle].MassFeed += Kick->SN_DeltaMass;
 #ifdef METALS
   PrimExch[particle].MetalsFeed += Kick->SN_DeltaMetals;
+#endif
+#ifdef DUST
+  PrimExch[particle].DustFeed += Kick->SN_DeltaDust;
 #endif
   for(int k = 0; k < 3; k++)
     PrimExch[particle].MomentumFeed[k] += Kick->SN_DeltaP[k];
@@ -256,6 +268,20 @@ static void SN_feedback_host(int i, int ev, int h, int mode)
 #endif
 #ifdef METALS
   Kick.SN_DeltaMetals = MechanicalFeedback->SN_MetalsLoss;
+#endif
+#ifdef DUST
+  /* HOST mode fires when the host cell is much smaller than the SN remnant
+   * (r_host < r_SN/10, see SN_feedback_radius()) -- there is no swept-mass
+   * split to compute here, so the whole cell is treated as processed by the
+   * shock: all of its pre-existing dust is destroyed, and freshly-condensed
+   * SN dust is added. */
+  {
+    double host_dust     = SphP[i].GasDustMass + SphP[i].StarDustFeed;
+    double host_gas_mass = P[i].Mass + SphP[i].StarMassFeed;
+    double dust_destroyed =
+        dust_destruction_sn(DUST_PHASE1_SPECIES, host_dust, host_gas_mass, host_gas_mass, 1.0);
+    Kick.SN_DeltaDust = dust_production_sn(DUST_PHASE1_SPECIES, MechanicalFeedback->SN_MetalsLoss) - dust_destroyed;
+  }
 #endif
   /* Advected mass only: ejecta carries the star's own velocity */
   for(k = 0; k < 3; k++)
@@ -578,6 +604,15 @@ void star_feedback(void)
           double dmZ_h = dm_h * (SphP[i].GasMetals + SphP[i].StarMetalsFeed) / m_h;
 #endif
 
+#ifdef DUST
+          /* Dust contained in the swept mass: destroyed by the shock, not
+           * redistributed intact like dmZ_h (see dust.h). Implemented via
+           * dust_destruction_sn() with dm_h itself as the McKee-style
+           * destroy-mass threshold, so it reduces exactly to the swept-mass
+           * fraction of the host's current dust. */
+          double dmD_h = dust_destruction_sn(DUST_PHASE1_SPECIES, SphP[i].GasDustMass + SphP[i].StarDustFeed, m_h, dm_h, 1.0);
+#endif
+
           double p_h[3], v_h[3];
           for(k = 0; k < 3; k++)
             {
@@ -768,6 +803,12 @@ void star_feedback(void)
 #ifdef METALS
                   Kick.SN_DeltaMetals = (MechanicalFeedback->SN_MetalsLoss + dmZ_h) * sqrtsq_wbar ;
 #endif
+#ifdef DUST
+                  /* Only freshly-condensed SN dust is redistributed here --
+                   * the swept host dust (dmD_h) was destroyed, not carried
+                   * along, unlike the metal tracer mass. */
+                  Kick.SN_DeltaDust = dust_production_sn(DUST_PHASE1_SPECIES, MechanicalFeedback->SN_MetalsLoss) * sqrtsq_wbar;
+#endif
                   /* Momentum = advected (ejecta @ v_star + host @ v_host)
                    * + directed energy-conserving kick p_SN * wbar.          */
                   for(k = 0; k < 3; k++)
@@ -828,6 +869,9 @@ void star_feedback(void)
 #endif
 #ifdef METALS
               Kick_h.SN_DeltaMetals = -dmZ_h;
+#endif
+#ifdef DUST
+              Kick_h.SN_DeltaDust = -dmD_h; /* swept dust destroyed, not returned */
 #endif
               for(k = 0; k < 3; k++)
                 Kick_h.SN_DeltaP[k] = -dm_h * v_h[k];

--- a/src/stars/star_update.c
+++ b/src/stars/star_update.c
@@ -420,10 +420,26 @@ void star_perform_end_of_step_physics(void)
       /* Add metals */
       SphP[i].GasMetals += SphP[i].StarMetalsFeed;
       All.StarFeedbackLocal[4] += SphP[i].StarMetalsFeed;
-      
+
       sync_primitive_from_conserved(i, METALS_INDEX);
 
       SphP[i].StarMetalsFeed = 0;
+#endif
+#ifdef DUST
+      /* Add SN-condensed dust minus SN-shock-destroyed dust (see
+       * star_feedback.c); clamp to the physical invariant
+       * 0 <= GasDustMass <= GasMetals (dust can never exceed the metal
+       * budget it condensed from -- GasMetals was just updated above). */
+      SphP[i].GasDustMass += SphP[i].StarDustFeed;
+
+      if(SphP[i].GasDustMass < 0)
+        SphP[i].GasDustMass = 0;
+      if(SphP[i].GasDustMass > SphP[i].GasMetals)
+        SphP[i].GasDustMass = SphP[i].GasMetals;
+
+      sync_primitive_from_conserved(i, DUST_INDEX);
+
+      SphP[i].StarDustFeed = 0;
 #endif
 #endif
             

--- a/tests/dust/build.sh
+++ b/tests/dust/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Standalone build for the dust rate-law unit test. Deliberately bypasses
+# the main Makefile (no MPI/HDF5/GSL needed): the pure rate-law files in
+# src/dust/ only depend on dust.h/dust_proto.h and libm.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+cc -std=c99 -Wall -Wextra -DDUST -o test_dust_rates \
+  test_dust_rates.c \
+  ../../src/dust/dust_production_sn.c \
+  ../../src/dust/dust_destruction_sn.c \
+  ../../src/dust/dust_growth.c \
+  ../../src/dust/dust_sputtering.c \
+  -lm
+
+./test_dust_rates

--- a/tests/dust/test_dust_rates.c
+++ b/tests/dust/test_dust_rates.c
@@ -55,12 +55,15 @@ int main(void)
   CHECK(dust_destruction_sn(DUST_PHASE1_SPECIES, 10.0, 1e4, 1e3, 0.0) == 0.0, "destruction_sn: zero weight -> zero destroyed");
 
   {
-    /* threshold == cell_gas_mass, weight=1 -> full destruction */
-    double destroyed = dust_destruction_sn(DUST_PHASE1_SPECIES, 10.0, 1000.0, 1000.0, 1.0);
-    CHECK(fabs(destroyed - 10.0) < 1e-9, "destruction_sn: threshold==cell mass, weight=1 -> destroys all dust");
+    /* threshold == cell_gas_mass / DUST_SN_DESTRUCTION_EFFICIENCY, weight=1
+     * -> exactly the destruction efficiency's worth of the swept mass
+     * destroys all the dust */
+    double threshold = 1000.0 / DUST_SN_DESTRUCTION_EFFICIENCY;
+    double destroyed  = dust_destruction_sn(DUST_PHASE1_SPECIES, 10.0, 1000.0, threshold, 1.0);
+    CHECK(fabs(destroyed - 10.0) < 1e-9, "destruction_sn: threshold at the efficiency-scaled cap -> destroys all dust");
   }
   {
-    /* threshold > cell_gas_mass must still cap at destroying all dust, not overshoot */
+    /* threshold beyond that must still cap at destroying all dust, not overshoot */
     double destroyed = dust_destruction_sn(DUST_PHASE1_SPECIES, 10.0, 1000.0, 5000.0, 1.0);
     CHECK(fabs(destroyed - 10.0) < 1e-9, "destruction_sn: oversized threshold caps at full destruction, no overshoot");
   }
@@ -72,27 +75,36 @@ int main(void)
   }
 
   /* --- dust_growth_rate ------------------------------------------------ */
-  CHECK(dust_growth_rate(DUST_PHASE1_SPECIES, 0.0, 100.0, 1e3, 20.0) == 0.0, "growth_rate: zero dust mass -> zero rate");
-  CHECK(dust_growth_rate(DUST_PHASE1_SPECIES, 50.0, 50.0, 1e3, 20.0) == 0.0,
+  CHECK(dust_growth_rate(DUST_PHASE1_SPECIES, 0.0, 100.0, 1e3, 20.0, 0.02) == 0.0, "growth_rate: zero dust mass -> zero rate");
+  CHECK(dust_growth_rate(DUST_PHASE1_SPECIES, 50.0, 50.0, 1e3, 20.0, 0.02) == 0.0,
         "growth_rate: M_dust==M_metal (fully condensed) -> zero rate (saturated)");
+  CHECK(dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e3, 20.0, 0.0) == 0.0,
+        "growth_rate: zero gas-phase metallicity -> zero rate (guarded)");
 
   {
-    double rate = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e3, 20.0);
+    double rate = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e3, 20.0, 0.02);
     CHECK(rate > 0.0, "growth_rate: 0 < M_dust < M_metal -> positive growth rate");
   }
   {
     /* Higher density -> shorter growth timescale -> higher rate */
-    double rate_lo = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e2, 20.0);
-    double rate_hi = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e4, 20.0);
+    double rate_lo = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e2, 20.0, 0.02);
+    double rate_hi = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e4, 20.0, 0.02);
     CHECK(rate_hi > rate_lo, "growth_rate: rate increases with density");
   }
   {
-    /* Dwek (1998)/Hirashita (2000) accretion timescale scales as 1/sqrt(T)
-     * (collision rate with thermal velocity), so tau shortens -- and the
-     * rate rises -- as T increases. */
-    double rate_cold = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e3, 20.0);
-    double rate_hot   = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e3, 2000.0);
+    /* Li+2019 eq. 5: accretion timescale scales linearly as 1/T (not
+     * 1/sqrt(T)), so tau shortens -- and the rate rises -- as T increases. */
+    double rate_cold = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e3, 20.0, 0.02);
+    double rate_hot   = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e3, 2000.0, 0.02);
     CHECK(rate_hot > rate_cold, "growth_rate: rate increases with temperature (faster thermal collisions)");
+  }
+  {
+    /* Li+2019 eq. 5: accretion timescale scales as 1/Z_gas, so higher
+     * gas-phase metallicity (more metals available to accrete) -> shorter
+     * tau -> higher rate. */
+    double rate_lo_z = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e3, 20.0, 0.001);
+    double rate_hi_z = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e3, 20.0, 0.1);
+    CHECK(rate_hi_z > rate_lo_z, "growth_rate: rate increases with gas-phase metallicity");
   }
 
   /* --- dust_sputtering_rate --------------------------------------------- */
@@ -116,7 +128,7 @@ int main(void)
      * driving growth (M_dust == M_metal keeps growth at exactly zero via
      * saturation), only sputtering can move M -- confirm it does not
      * spontaneously produce dust out of nothing at M_dust == 0. */
-    double g = dust_growth_rate(DUST_PHASE1_SPECIES, 0.0, 100.0, 1e3, 20.0);
+    double g = dust_growth_rate(DUST_PHASE1_SPECIES, 0.0, 100.0, 1e3, 20.0, 0.02);
     double s = dust_sputtering_rate(DUST_PHASE1_SPECIES, 0.0, 1.0, 1e6);
     CHECK(g == 0.0 && s == 0.0, "combined: M_dust=0 is a fixed point of growth+sputtering (no spontaneous creation)");
   }

--- a/tests/dust/test_dust_rates.c
+++ b/tests/dust/test_dust_rates.c
@@ -1,0 +1,127 @@
+/*
+ * Standalone unit test for the dust module's pure rate-law functions
+ * (src/dust/dust_production_sn.c, dust_destruction_sn.c, dust_growth.c,
+ * dust_sputtering.c).
+ *
+ * Deliberately decoupled from the rest of Arepo: no MPI, no mesh, no
+ * SphP/P globals -- these rate-law files only depend on dust.h/dust_proto.h
+ * and libm, so they can be compiled and exercised standalone. See
+ * tests/dust/build.sh.
+ *
+ * This checks conservation/limit properties of the rate laws themselves,
+ * not their numerical integration in dust_cell() (src/dust/dust_update.c),
+ * which requires the full Arepo build (see the Phase 1 implementation
+ * plan's "What I can verify myself vs. what needs you" section).
+ */
+
+#include <math.h>
+#include <stdio.h>
+
+#include "../../src/dust/dust.h"
+#include "../../src/dust/dust_proto.h"
+
+static int g_failures = 0;
+
+#define CHECK(cond, msg)                                    \
+  do                                                         \
+    {                                                        \
+      if(!(cond))                                            \
+        {                                                    \
+          printf("FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__); \
+          g_failures++;                                      \
+        }                                                    \
+      else                                                   \
+        {                                                    \
+          printf("PASS: %s\n", msg);                         \
+        }                                                    \
+    }                                                        \
+  while(0)
+
+int main(void)
+{
+  /* --- dust_production_sn ------------------------------------------- */
+  CHECK(dust_production_sn(DUST_PHASE1_SPECIES, 0.0) == 0.0, "production_sn: zero metal loss -> zero dust");
+  CHECK(dust_production_sn(DUST_PHASE1_SPECIES, -1.0) == 0.0, "production_sn: negative input -> zero dust (guarded)");
+
+  {
+    double m = 100.0;
+    double d = dust_production_sn(DUST_PHASE1_SPECIES, m);
+    CHECK(d > 0.0 && d < m, "production_sn: positive input -> 0 < dust < metal loss");
+    CHECK(fabs(d - DUST_SN_CONDENSATION_EFFICIENCY * m) < 1e-12, "production_sn: matches condensation efficiency exactly");
+  }
+
+  /* --- dust_destruction_sn -------------------------------------------- */
+  CHECK(dust_destruction_sn(DUST_PHASE1_SPECIES, 0.0, 1e4, 1e3, 1.0) == 0.0, "destruction_sn: zero dust -> zero destroyed");
+  CHECK(dust_destruction_sn(DUST_PHASE1_SPECIES, 10.0, 1e4, 1e3, 0.0) == 0.0, "destruction_sn: zero weight -> zero destroyed");
+
+  {
+    /* threshold == cell_gas_mass, weight=1 -> full destruction */
+    double destroyed = dust_destruction_sn(DUST_PHASE1_SPECIES, 10.0, 1000.0, 1000.0, 1.0);
+    CHECK(fabs(destroyed - 10.0) < 1e-9, "destruction_sn: threshold==cell mass, weight=1 -> destroys all dust");
+  }
+  {
+    /* threshold > cell_gas_mass must still cap at destroying all dust, not overshoot */
+    double destroyed = dust_destruction_sn(DUST_PHASE1_SPECIES, 10.0, 1000.0, 5000.0, 1.0);
+    CHECK(fabs(destroyed - 10.0) < 1e-9, "destruction_sn: oversized threshold caps at full destruction, no overshoot");
+  }
+  {
+    /* linear scaling in threshold, below the cap */
+    double d1 = dust_destruction_sn(DUST_PHASE1_SPECIES, 10.0, 1000.0, 100.0, 1.0);
+    double d2 = dust_destruction_sn(DUST_PHASE1_SPECIES, 10.0, 1000.0, 200.0, 1.0);
+    CHECK(fabs(d2 - 2.0 * d1) < 1e-9, "destruction_sn: linear in destroy_mass_threshold below the cap");
+  }
+
+  /* --- dust_growth_rate ------------------------------------------------ */
+  CHECK(dust_growth_rate(DUST_PHASE1_SPECIES, 0.0, 100.0, 1e3, 20.0) == 0.0, "growth_rate: zero dust mass -> zero rate");
+  CHECK(dust_growth_rate(DUST_PHASE1_SPECIES, 50.0, 50.0, 1e3, 20.0) == 0.0,
+        "growth_rate: M_dust==M_metal (fully condensed) -> zero rate (saturated)");
+
+  {
+    double rate = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e3, 20.0);
+    CHECK(rate > 0.0, "growth_rate: 0 < M_dust < M_metal -> positive growth rate");
+  }
+  {
+    /* Higher density -> shorter growth timescale -> higher rate */
+    double rate_lo = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e2, 20.0);
+    double rate_hi = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e4, 20.0);
+    CHECK(rate_hi > rate_lo, "growth_rate: rate increases with density");
+  }
+  {
+    /* Dwek (1998)/Hirashita (2000) accretion timescale scales as 1/sqrt(T)
+     * (collision rate with thermal velocity), so tau shortens -- and the
+     * rate rises -- as T increases. */
+    double rate_cold = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e3, 20.0);
+    double rate_hot   = dust_growth_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e3, 2000.0);
+    CHECK(rate_hot > rate_cold, "growth_rate: rate increases with temperature (faster thermal collisions)");
+  }
+
+  /* --- dust_sputtering_rate --------------------------------------------- */
+  CHECK(dust_sputtering_rate(DUST_PHASE1_SPECIES, 0.0, 1.0, 1e6) == 0.0, "sputtering_rate: zero dust mass -> zero rate");
+
+  {
+    double rate = dust_sputtering_rate(DUST_PHASE1_SPECIES, 10.0, 1.0, 1e6);
+    CHECK(rate < 0.0, "sputtering_rate: positive dust mass -> negative (destructive) rate");
+    CHECK(fabs(rate) < 10.0 * 1e6, "sputtering_rate: magnitude is finite and not absurd");
+  }
+  {
+    /* Lower density -> longer sputtering timescale -> smaller |rate| */
+    double rate_lo_n = dust_sputtering_rate(DUST_PHASE1_SPECIES, 10.0, 0.01, 1e6);
+    double rate_hi_n = dust_sputtering_rate(DUST_PHASE1_SPECIES, 10.0, 100.0, 1e6);
+    CHECK(fabs(rate_hi_n) > fabs(rate_lo_n), "sputtering_rate: |rate| increases with density");
+  }
+
+  /* --- combined: zero-rate no-op (Phase 0 exit-gate spirit) -------------- */
+  {
+    /* With M_dust already at the metal budget and negligible density/temp
+     * driving growth (M_dust == M_metal keeps growth at exactly zero via
+     * saturation), only sputtering can move M -- confirm it does not
+     * spontaneously produce dust out of nothing at M_dust == 0. */
+    double g = dust_growth_rate(DUST_PHASE1_SPECIES, 0.0, 100.0, 1e3, 20.0);
+    double s = dust_sputtering_rate(DUST_PHASE1_SPECIES, 0.0, 1.0, 1e6);
+    CHECK(g == 0.0 && s == 0.0, "combined: M_dust=0 is a fixed point of growth+sputtering (no spontaneous creation)");
+  }
+
+  printf("\n%s (%d failure%s)\n", g_failures == 0 ? "ALL TESTS PASSED" : "TESTS FAILED", g_failures, g_failures == 1 ? "" : "s");
+
+  return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Phase 1 of the dust-module implementation plan: a single-scalar dust mass carried per gas cell, with SN-channel production, McKee (1989)-style SN shock destruction, Dwek (1998)-style grain growth, and Tsai & Mathews (1995)-style thermal sputtering — wired into the existing passive-scalar advection, SN feedback, timestep, and snapshot I/O machinery.

This is a clean cherry-pick of `dust_module`'s own 17 commits onto current `main`, deliberately decoupled from `Star_feedback_radiation`'s independent drift (which `dust_module` was originally branched from, but which has since diverged from `main` in ways unrelated to dust). See individual commit messages for full detail; highlights:

- `src/dust/` — production/destruction/growth/sputtering rate laws as pure, standalone-testable functions, plus the per-cell rate-ODE integration pass (`dust_cell()`/`dust_processes()`, mirroring `DoCooling()`/`cooling_only()`).
- `DUST` passive scalar added to the existing generic `N_Scalar`/`PASSIVE_SCALARS` advection framework (Voronoi flux, MPI exchange, refinement/derefinement all come for free), plus a dedicated `DustMass` snapshot field.
- SN-channel production/destruction hooked into the existing per-SN-event `Feedback_Kick` mechanism in `src/stars/star_feedback.c`.
- **Rate-law constants verified against Li, Narayanan & Dave (2019)** primary text and Table 1 (not an AI-summarized secondary source) — every constant/functional form was checked and, where wrong, corrected.
- A small, unrelated-to-dust fix folded in: a dedicated `Metallicity` snapshot field for gas cells (`PartType0`), mirroring the field stars already have and the pattern `DustMass` already uses — previously gas metallicity was only reachable via the opaque `PassiveScalars` array.
- `examples/agora_disc_star_formation_3d/`: `DUST` added to `Config.sh`, plus `check.py`/diagnostics-script extensions for metals/dust sanity checks and profiles.
- `examples/dust_isolated_disk_3d/`: scaffold only, no IC included.
- `tests/dust/`: standalone unit-test harness (no MPI/mesh), 21 checks.

Cherry-pick conflicts (all resolved, see individual commits): a handful of enum/init-list append conflicts where `main`'s SIDM/HALO_SEEDING additions landed at the same insertion point as dust's — resolved by keeping both. One pulled-from-main-example commit was superseded by main's own newer version of that example (only its actual delta, `DUST` in `Config.sh`, was ported). One Makefile fix commit was dropped entirely — `main` had already independently fixed the exact same `SYSTYPE`/`GRACKLE_DIR` bugs.

## Test plan

- [x] `tests/dust/build.sh` — all 21 standalone rate-law unit tests pass
- [x] Full build (`DUST` Config.sh flag on) links cleanly against current `main`, `SIDM`+`HALO_SEEDING` included
- [x] Forced-fast-SN run on `examples/agora_disc_star_formation_3d/`: dust appears at first SN, spreads correctly across the mesh, metal mass and star count monotonically non-decreasing, zero `0 <= DustMass <= GasMetals` invariant violations across all snapshots (`check.py`'s full 5-check suite)
- [x] Reviewer: confirm scope decisions in `DUST_PHASE1_IMPLEMENTATION.md` (SN-channel-only production; destruction reuses Kim & Ostriker 2015 swept-mass estimate rather than an independent literature constant) are acceptable for Phase 1